### PR TITLE
Remove transportCallID in shipmentEvent

### DIFF
--- a/tnt/v2/tnt.yaml
+++ b/tnt/v2/tnt.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.0.0"
+  version: 2.0.1
   title: 'DCSA OpenAPI specification for Track & Trace'
   description: 'API specification issued by DCSA.org'
   license:
@@ -114,7 +114,6 @@ paths:
                   eventDateTime: "2019-11-12T07:41:00+08:30"
                   eventClassifierCode: "ACT"
                   eventTypeCode: "ARRI"
-                  transportCallID: 7
                   shipmentInformationTypeCode: "SRM"
         default:
           description: Unexpected error
@@ -293,8 +292,6 @@ components:
           $ref: '#/components/schemas/eventClassifierCode'
         eventTypeCode:
           $ref: '#/components/schemas/eventTypeCode'
-        transportCallID:
-          $ref: '#/components/schemas/transportCallID'    
       required:
         - eventID
         - eventType
@@ -366,6 +363,8 @@ components:
               $ref: '#/components/schemas/delayReasonCode'
             vesselScheduleChangeRemark:
               $ref: '#/components/schemas/vesselScheduleChangeRemark'
+            transportCallID:
+              $ref: '#/components/schemas/transportCallID'      
           required:
             - transportCallID
     equipmentEvent:
@@ -404,8 +403,11 @@ components:
               $ref: '#/components/schemas/equipmentReference'
             emptyIndicatorCode:
               $ref: '#/components/schemas/emptyIndicatorCode'
+            transportCallID:
+              $ref: '#/components/schemas/transportCallID'    
           required:
             - emptyIndicatorCode
+            - transportCallID
     events:
       type: array
       description: List of events for shipment journey.

--- a/tnt/v2/tnt.yaml
+++ b/tnt/v2/tnt.yaml
@@ -619,8 +619,8 @@ components:
       nullable: false
     transportCallID:
       description: The unique identifier for a transport call
-      type: number
-      example: 7
+      type: string
+      example: "7"
       nullable: false
   headers:
     signatureHeader:

--- a/tnt/v2/tnt.yaml
+++ b/tnt/v2/tnt.yaml
@@ -508,7 +508,8 @@ components:
       description: The unique identifier for the equipment, which should follow the BIC ISO Container Identification Number where possible. If a container is not yet assigned to a shipment, the interface cannot return any information when an equipment reference is given as input. If a container is assigned to an (active) shipment, the interface returns information on the active shipment.
     transportDocumentID:
       type: string
-      example: ABCD421911263977
+      format: uuid
+      example: 123e4567-e89b-12d3-a456-426614174000
       maxLength: 20
       description: The Transport Document ID number is an identifier that links to a shipment, i.e. a Bill of Lading or a Sea Waybill. A bill of lading is the document of title to the goods issued to the customer which confirms the carrier's receipt of the cargo from the customer, acknowledging goods being shipped and specifying the terms of delivery. 
         The Sea Waybill is a simpler document, the main difference being that it is non-negotiable. 

--- a/tnt/v2/tnt.yaml
+++ b/tnt/v2/tnt.yaml
@@ -114,6 +114,7 @@ paths:
                   eventDateTime: "2019-11-12T07:41:00+08:30"
                   eventClassifierCode: "ACT"
                   eventTypeCode: "ARRI"
+                  shipmentID: "123e4567-e89b-12d3-a456-426614174000"
                   shipmentInformationTypeCode: "SRM"
         default:
           description: Unexpected error
@@ -336,6 +337,8 @@ components:
                 - PENA (Pending approval)
             shipmentInformationTypeCode:
               $ref: '#/components/schemas/shipmentInformationTypeCode'
+            shipmentID:
+              $ref: '#/components/schemas/shipmentID'
           required:
             - shipmentInformationTypeCode
     transportEvent:
@@ -613,6 +616,12 @@ components:
       type: string
       example: Bad weather
       maxLength: 250
+    shipmentID:
+      description: ID uniquely identifying a shipment
+      type: string
+      format: uuid
+      example: 123e4567-e89b-12d3-a456-426614174000
+      nullable: false
     scheduleID:
       description: ID uniquely identifying a schedule
       type: string

--- a/tnt/v2/tnt.yaml
+++ b/tnt/v2/tnt.yaml
@@ -449,7 +449,7 @@ components:
           type: string
           example: Bad Request
         errorDateTime:
-          description: The date and time (in ISO 8601 format) the error occured.
+          description: The date and time (in ISO 8601 format) the error occurred.
           type: string
           example: '2019-11-12T07:41:00+08:30'
     errors:
@@ -614,13 +614,15 @@ components:
       maxLength: 250
     scheduleID:
       description: ID uniquely identifying a schedule
-      type: number
-      example: 3
+      type: string
+      format: uuid
+      example: 123e4567-e89b-12d3-a456-426614174000
       nullable: false
     transportCallID:
       description: The unique identifier for a transport call
       type: string
-      example: "7"
+      format: uuid
+      example: 123e4567-e89b-12d3-a456-426614174000
       nullable: false
   headers:
     signatureHeader:

--- a/tnt/v2/tnt.yaml
+++ b/tnt/v2/tnt.yaml
@@ -109,7 +109,7 @@ paths:
                 discriminator:
                   propertyName: eventType
                 example: #Couldn't use $ref in this example. Should be updated manually if shipmentEvent changes
-                  eventID: "1"
+                  eventID: "84db923d-2a19-4eb0-beb5-446c1ec57d34"
                   eventType: "SHIPMENT"
                   eventDateTime: "2019-11-12T07:41:00+08:30"
                   eventClassifierCode: "ACT"
@@ -511,8 +511,7 @@ components:
       description: The unique identifier for the equipment, which should follow the BIC ISO Container Identification Number where possible. If a container is not yet assigned to a shipment, the interface cannot return any information when an equipment reference is given as input. If a container is assigned to an (active) shipment, the interface returns information on the active shipment.
     transportDocumentID:
       type: string
-      format: uuid
-      example: 123e4567-e89b-12d3-a456-426614174000
+      example: ABCD421911263977
       maxLength: 20
       description: The Transport Document ID number is an identifier that links to a shipment, i.e. a Bill of Lading or a Sea Waybill. A bill of lading is the document of title to the goods issued to the customer which confirms the carrier's receipt of the cargo from the customer, acknowledging goods being shipped and specifying the terms of delivery. 
         The Sea Waybill is a simpler document, the main difference being that it is non-negotiable. 
@@ -560,7 +559,8 @@ components:
       description: The local date and time, where the event took place, in ISO 8601 format.
     eventID:
       type: string
-      example: "1"
+      format: uuid
+      example: "84db923d-2a19-4eb0-beb5-446c1ec57d34"
       description: The unique identifier for the Equipment Event ID/Transport Event ID/Shipment Event ID.
       nullable: false
     eventClassifierCode:


### PR DESCRIPTION
As reported in #12, transportCallID should not be part of the Event object, as the Shipment Event subtype does not have the property