### PR TITLE
Update dcsa_domain.yaml

### DIFF
--- a/domain/dcsa_domain.yaml
+++ b/domain/dcsa_domain.yaml
@@ -71,16 +71,6 @@ components:
       maxLength: 35
       example: ABC709951
       description: 'A set of unique characters provided by carrier to identify a booking.'
-    # A way to extend carrierBookingReference and modifying the description
-    carrierBookingReferenceSIHeader:
-      allOf:
-        - $ref: '#/components/schemas/carrierBookingReference'
-      description: 'The associated booking number provided by the carrier. Cannot be used in combination with Cargo Item level carrierBookingReference'
-    # A way to extend carrierBookingReference and modifying the description
-    carrierBookingReferenceCargoItem:
-      allOf:
-        - $ref: '#/components/schemas/carrierBookingReference'
-      description: 'The associated booking number provided by the carrier for this cargo item. Cannot be used in combination with Shipping Instruction header level carrierBookingReference'
     carrierServiceCode:
       description: The code of the service for which the schedule details are published.
       type: string
@@ -800,4 +790,3 @@ components:
       schema:
         type: string
       example: fE9mZnNldHw9MTAmbGltaXQ9MTA=
-      


### PR DESCRIPTION
Removed extended carrierBookingReferences and moved them to DCSA_EBL_DOMAIN - since the extending does not work when extending on a locally defined component (needs to be in a different file - hence in DCSA_EBL_DOMAIN)