### PR TITLE
Update dcsa_ebl_domain.yaml

### DIFF
--- a/domain/dcsa_ebl_domain.yaml
+++ b/domain/dcsa_ebl_domain.yaml
@@ -40,11 +40,19 @@ components:
         - type: object
           properties:
             freightPayableAt:
-              $ref: '#/components/schemas/unLocodeCityLocationExample'
+              $ref: '#/components/schemas/location'
+        # Extending freightPayableAt in order to alter example and description
         - type: object
           properties:
-            preCarriageUnderShippersResponsibility:
-              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/preCarriageUnderShippersResponsibility'
+            freightPayableAt:
+              description: 'A location object - here with an example with only UN location code and City name present'
+              example:
+                locationID: '123e4567-e89b-12d3-a456-426614174000'
+                UNLocationCode: 'USNYC'
+                address:
+                  cityName: 'København'
+                  stateRegion: 'N/A'
+                  country: 'Denmark'
         - type: object
           properties:
             isElectronic:
@@ -52,7 +60,12 @@ components:
         - type: object
           properties:
             carrierBookingReference:
-              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/carrierBookingReferenceSIHeader'
+              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/carrierBookingReference'
+        # Extend the carrierBookingReference description for SI
+        - type: object
+          properties:
+            carrierBookingReference:
+              description: 'The associated booking number provided by the carrier. Cannot be used in combination with Cargo Item level carrierBookingReference'
         - type: object
           properties:
             callbackUrl:
@@ -144,7 +157,13 @@ components:
         - type: object
           properties:
             carrierBookingReference:
-              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/carrierBookingReferenceCargoItem'
+              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/carrierBookingReference'
+        # Extend the carrierBookingReference description for CargoItem
+        - type: object
+          properties:
+            carrierBookingReference:
+              description: 'The associated booking number provided by the carrier for this cargo item. Cannot be used in combination with Shipping Instruction header level carrierBookingReference'
+
         - type: object
           properties:
             descriptionOfGoods:
@@ -343,16 +362,7 @@ components:
             displayedAddress:
               type: array
               items:
-                type: object
-                allOf:
-                  - type: object
-                    properties:
-                      addressLine:
-                        $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/addressLine'
-                  - type: object
-                    properties:
-                      addressLineNumber:
-                        $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/addressLineNumber'
+                $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/addressLine'
         - type: object
           properties:
             partyContactDetails:
@@ -550,10 +560,6 @@ components:
           properties:
             issuer:
               $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/issuer'
-        - type: object
-          properties:
-            shippingInstructionID:
-              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/shippingInstructionID'
         - type: object
           properties:
             declaredValueCurrency:
@@ -798,21 +804,10 @@ components:
         - type: object
           properties:
             address:
+              description: 'Address related information'
               allOf:
                 - $ref: '#/components/schemas/address'
 
-    unLocodeCityLocationExample:
-      type: object
-      description: 'A location object - here with an example with only UN location code and City name present'
-      allOf:
-        - $ref: '#/components/schemas/location'
-      example: #Display example only using UNLocode and City
-        locationID: "123e4567-e89b-12d3-a456-426614174000"
-        UNLocationCode: "USNYC"
-        cityName: "København"
-        stateRegion: N/A
-        country: Denmark
-        
     address:
       type: object
       description: 'An object for storing address related information'


### PR DESCRIPTION
Extend freightPayableAt and carrierBookingReference (both in CargoItem and ShippingInstruction) locally instead of defining a new component
Modify freightPayableAt example to reflect new structure
Modify displayedAddress to reflect new structure