### PR TITLE
API definition transferred by SwaggerHub

### DIFF
--- a/ebl/v1/ebl.yaml
+++ b/ebl/v1/ebl.yaml
@@ -11,48 +11,7 @@ info:
     url: https://dcsa.org
     email: info@dcsa.org
 paths:
-  /shipping-instructions:
-    post:
-      tags:
-       - Shipping Instructions
-      summary: Post shipping instruction
-      description: |
-        Creates a new shipping instruction
-      requestBody:
-        description: Parameters used to create the shipping instruction
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EBL_DOMAIN/1.0.0#/components/schemas/shippingInstructionNoID'
-      responses:
-        '202':
-          description: Shipping Instruction accepted
-          content:
-            application/json:
-              schema:
-                $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EBL_DOMAIN/1.0.0#/components/schemas/shippingInstruction'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/error'
-      callbacks:
-        shipmentEvent:
-          '{$request.body.callbackUrl}':
-            post:
-              parameters:
-                - $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EVENT_DOMAIN/1.0.0#/components/parameters/signatureHeaderParam'
-              requestBody:
-                required: true
-                content:
-                  application/json:
-                    schema:
-                      $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EVENT_DOMAIN/1.0.0#/components/schemas/shipmentEvent'
-              responses:
-                '200':
-                  description: 'Your server returns this code if it accepts the callback'          
+  /v1/shipping-instructions-summeries:
     get:
       tags:
        - Shipping Instructions
@@ -71,7 +30,7 @@ paths:
             API-Version:
               schema:
                 type: string
-                example: 'v0.4.0'
+                example: '1.0.0'
               description: SemVer used to indicate the version of the contract (API version) returned.
               required: false
             Current-Page:
@@ -115,8 +74,50 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/error'            
-  /shipping-instructions/{shippingInstructionID}:
+                $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/error'
+  /v1/shipping-instructions:
+    post:
+      tags:
+       - Shipping Instructions
+      summary: Post shipping instruction
+      description: |
+        Creates a new shipping instruction
+      requestBody:
+        description: Parameters used to create the shipping instruction
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EBL_DOMAIN/1.0.0#/components/schemas/shippingInstructionNoID'
+      responses:
+        '202':
+          description: Shipping Instruction accepted
+          content:
+            application/json:
+              schema:
+                $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EBL_DOMAIN/1.0.0#/components/schemas/shippingInstruction'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/error'
+      callbacks:
+        shipmentEvent:
+          '{$request.body.callbackUrl}':
+            post:
+              parameters:
+                - $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EVENT_DOMAIN/1.0.0#/components/parameters/signatureHeaderParam'
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EVENT_DOMAIN/1.0.0#/components/schemas/shipmentEvent'
+              responses:
+                '200':
+                  description: 'Your server returns this code if it accepts the callback'          
+  /v1/shipping-instructions/{shippingInstructionID}:
     get:
       tags:
        - Shipping Instructions
@@ -131,7 +132,7 @@ paths:
             API-Version:
               schema:
                 type: string
-                example: 'v0.4.0'
+                example: '1.0.0'
               description: SemVer used to indicate the version of the contract (API version) returned.
               required: false
           content:
@@ -160,13 +161,13 @@ paths:
             schema:
               $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_EBL_DOMAIN/1.0.0#/components/schemas/shippingInstructionNoDS'
       responses:
-        '200':
-          description: Shipping Instruction updated
+        '202':
+          description: Shipping Instruction accepted
           headers:
             API-Version:
               schema:
                 type: string
-                example: 'v0.4.0'
+                example: '1.0.0'
               description: SemVer used to indicate the version of the contract (API version) returned.
               required: false
           content:
@@ -179,7 +180,7 @@ paths:
             application/json:
               schema:
                 $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/error'            
-  /transport-documents:
+  /v1/transport-documents-summeries:
     get:
       tags:
        - Transport Documents
@@ -198,7 +199,7 @@ paths:
             API-Version:
               schema:
                 type: string
-                example: 'v0.4.0'
+                example: '1.0.0'
               description: SemVer used to indicate the version of the contract (API version) returned.
               required: false
             Current-Page:
@@ -243,7 +244,7 @@ paths:
             application/json:
               schema:
                 $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/error'
-  /transport-documents/{transportDocumentID}:
+  /v1/transport-documents/{transportDocumentID}:
     get:
       tags:
        - Transport Documents
@@ -259,10 +260,10 @@ paths:
             API-Version:
               schema:
                 type: string
-                example: 'v0.4.0'
+                example: '1.0.0'
               description: SemVer used to indicate the version of the contract (API version) returned.
               required: false
-            X-Document-Signature:
+            Document-Signature:
               schema:
                 type: string
               description: The Carrier signature of the Transport Document
@@ -276,7 +277,7 @@ paths:
             application/json:
               schema:
                 $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/error'
-  /transport-documents/{transportDocumentID}/approval:
+  /v1/transport-documents/{transportDocumentID}/approval:
     post:
       tags:
        - Transport Documents
@@ -293,7 +294,7 @@ paths:
             API-Version:
               schema:
                 type: string
-                example: 'v0.4.0'
+                example: '1.0.0'
               description: SemVer used to indicate the version of the contract (API version) returned.
               required: false
           content:


### PR DESCRIPTION
add v1 in beginning of path to reflect API Design guide
reordered paths
changed PUT response to 202 accepted instead of 200 OK to align with POST
Removed X as prefix for header name in order to align with API Design guide