### PR TITLE
API definition transferred by SwaggerHub

### DIFF
--- a/ovs/v1/ovs.yaml
+++ b/ovs/v1/ovs.yaml
@@ -344,10 +344,3 @@ components:
         $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/transportCallID'
       required: true
       description: The ID of the Transport Call to filter by.
-    eventID:
-      in: path
-      name: eventID
-      schema:
-        $ref: 'https://api.swaggerhub.com/domains/dcsaorg/EVENT_DOMAIN/1.0.0#/components/schemas/eventID'
-      required: true
-      description: The ID of the timestampID to filter by


### PR DESCRIPTION
Removed the complete eventId parameter as recently the coresponding GET endpoint was removed. (GET transportEvent/{eventID})
