### PR TITLE
Update ebl_domain.yaml

### DIFF
--- a/domain/ebl_domain.yaml
+++ b/domain/ebl_domain.yaml
@@ -531,10 +531,6 @@ components:
               $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/declaredValue'
         - type: object
           properties:
-            numberOfRiderPages:
-              $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/numberOfRiderPages'
-        - type: object
-          properties:
             shipmentTermAtOrigin:
               $ref: 'https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.0#/components/schemas/shipmentTermAtOrigin'
         - type: object


### PR DESCRIPTION
An attribute which is explicitly "Only applicable for physical transport documents" seems counter logical to include on an electronic version. I would suggest removal.