### PR TITLE
DT-823: Align requestedChange with ErrorResponse object

### DIFF
--- a/bkg/v2/BKG_v2.0.0-Beta-2.yaml
+++ b/bkg/v2/BKG_v2.0.0-Beta-2.yaml
@@ -1534,7 +1534,7 @@ paths:
                             cargoGrossWeightUnit: KGM
                     requestedChanges:
                       - jsonPath: $.requestedEquipment.units
-                        property: units
+                        property: 'units'
                         message: >-
                           Not enough available "42GP" equipment. Please change
                           to "22G1" instead

--- a/bkg/v2/BKG_v2.0.0-Beta-2.yaml
+++ b/bkg/v2/BKG_v2.0.0-Beta-2.yaml
@@ -1533,7 +1533,8 @@ paths:
                             cargoGrossWeight: 36000
                             cargoGrossWeightUnit: KGM
                     requestedChanges:
-                      - field: $.requestedEquipment.units
+                      - jsonPath: $.requestedEquipment.units
+                        property: units
                         message: >-
                           Not enough available "42GP" equipment. Please change
                           to "22G1" instead
@@ -2091,27 +2092,27 @@ components:
         A change required to the document in order for the carrier to accepted
         it
       properties:
-        field:
+        #field:
+        #  type: string
+        #  maxLength: 500
+        #  description: >
+        #    The field that caused the error, e.g. a failed validation. The field
+        #    can be expressed as a
+        #    [JSONpath](https://github.com/json-path/JsonPath) using either the
+        #    [DOT] Notation or the [Bracket] Notation.
+        #  example: $.location.facilityCode
+        property:
+          type: string
+          maxLength: 100
+          description: |
+            The name of the property causing the error.
+          example: 'facilityCode'
+        jsonPath:
           type: string
           maxLength: 500
-          description: >
-            The field that caused the error, e.g. a failed validation. The field
-            can be expressed as a
-            [JSONpath](https://github.com/json-path/JsonPath) using either the
-            [DOT] Notation or the [Bracket] Notation.
-          example: $.location.facilityCode
-        # property:
-        #   type: string
-        #   maxLength: 100
-        #   description: |
-        #     The name of the property causing the error.
-        #   example: 'facilityCode'
-        # jsonPath:
-        #   type: string
-        #   maxLength: 500
-        #   description: |
-        #     A path to the property causing the error, formatted according to [JSONpath](https://github.com/json-path/JsonPath).
-        #   example: '$.location.facilityCode'
+          description: |
+            A path to the property causing the error, formatted according to [JSONpath](https://github.com/json-path/JsonPath).
+          example: '$.location.facilityCode'
         message:
           type: string
           maxLength: 500

--- a/ebl/v3/EBL_v3.0.0-Beta-2.yaml
+++ b/ebl/v3/EBL_v3.0.0-Beta-2.yaml
@@ -731,7 +731,7 @@ paths:
                     requestedChanges:
                       - jsonPath: '$.advanceManifestFilings[0]'
                         message: Not a legal combination of "manifestTypeCode" (AFR) and "countryCode" (US)
-                      - jsonPath: $.advanceManifestFilings
+                      - jsonPath: '$.advanceManifestFilings'
                         message: Missing "ACI" filing required for import to US
                 dgExample:
                   summary: |

--- a/ebl/v3/EBL_v3.0.0-Beta-2.yaml
+++ b/ebl/v3/EBL_v3.0.0-Beta-2.yaml
@@ -729,9 +729,9 @@ paths:
                         advanceManifestFilingsHouseBLPerformedBy: SHIPPER
                         selfFilerCode: HHL007
                     requestedChanges:
-                      - field: '$.advanceManifestFilings[0]'
+                      - jsonPath: '$.advanceManifestFilings[0]'
                         message: Not a legal combination of "manifestTypeCode" (AFR) and "countryCode" (US)
-                      - field: $.advanceManifestFilings
+                      - jsonPath: $.advanceManifestFilings
                         message: Missing "ACI" filing required for import to US
                 dgExample:
                   summary: |
@@ -2860,24 +2860,24 @@ components:
       description: |
         A change required to the document in order for the carrier to accepted it
       properties:
-        field:
+        #field:
+        #  type: string
+        #  maxLength: 500
+        #  description: |
+        #    The field that caused the error, e.g. a failed validation. The field can be expressed as a [JSONpath](https://github.com/json-path/JsonPath) using either the [DOT] Notation or the [Bracket] Notation.
+        #  example: $.location.facilityCode
+        property:
+          type: string
+          maxLength: 100
+          description: |
+            The name of the property causing the error.
+          example: 'facilityCode'
+        jsonPath:
           type: string
           maxLength: 500
           description: |
-            The field that caused the error, e.g. a failed validation. The field can be expressed as a [JSONpath](https://github.com/json-path/JsonPath) using either the [DOT] Notation or the [Bracket] Notation.
-          example: $.location.facilityCode
-        # property:
-        #   type: string
-        #   maxLength: 100
-        #   description: |
-        #     The name of the property causing the error.
-        #   example: 'facilityCode'
-        # jsonPath:
-        #   type: string
-        #   maxLength: 500
-        #   description: |
-        #     A path to the property causing the error, formatted according to [JSONpath](https://github.com/json-path/JsonPath).
-        #   example: '$.location.facilityCode'
+            A path to the property causing the error, formatted according to [JSONpath](https://github.com/json-path/JsonPath).
+          example: '$.location.facilityCode'
         message:
           type: string
           maxLength: 500


### PR DESCRIPTION
DT-823: Split the `field` property into 2 properties: `property` and `jsonPath`. They are both optional so can be provided if needed (in the PR example - Booking uses both properties and in EBL only the `jsonPath` property is used)