### PR TITLE
DT-1007: Add subscriptionReference to Notification APIs

### DIFF
--- a/bkg/v2/notification/BKG_NTF_v2.0.0-Beta-2.yaml
+++ b/bkg/v2/notification/BKG_NTF_v2.0.0-Beta-2.yaml
@@ -15,6 +15,9 @@ info:
 
     For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/bkg/notification/v2#v200B2).
     Please also [create a GitHub issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any questions/comments.
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
   contact:
     name: Digital Container Shipping Association (DCSA)
     url: 'https://dcsa.org'
@@ -69,6 +72,7 @@ paths:
                   type: org.dcsa.booking-notification.v2
                   time: '2018-04-05T17:31:00Z'
                   datacontenttype: application/json
+                  subscriptionReference: BKG001
                   data:
                     bookingStatus: RECEIVED
                     carrierBookingRequestReference: 24595eb0-5cfc-4381-9c3a-cedc1975e9aa
@@ -85,6 +89,7 @@ paths:
                   type: org.dcsa.booking-notification.v2
                   time: '2018-04-05T17:31:00Z'
                   datacontenttype: application/json
+                  subscriptionReference: BKG001
                   data:
                     bookingStatus: CONFIRMED
                     amendedBookingStatus: AMENDMENT DECLINED
@@ -228,6 +233,13 @@ components:
           enum:
             - application/json
           example: application/json
+        subscriptionReference:
+          type: string
+          pattern: ^\S+(\s+\S+)*$
+          maxLength: 100
+          description: >
+            The reference of the subscription that has triggered this event
+          example: '30675492-50ff-4e17-a7df-7a487a8ad343'
         data:
           type: object
           description: |

--- a/bkg/v2/notification/BKG_NTF_v2.0.0-Beta-2.yaml
+++ b/bkg/v2/notification/BKG_NTF_v2.0.0-Beta-2.yaml
@@ -337,4 +337,5 @@ components:
         - type
         - time
         - datacontenttype
+        - subscriptionReference
         - data

--- a/ebl/v3/notification/EBL_NTF_v3.0.0-Beta-2.yaml
+++ b/ebl/v3/notification/EBL_NTF_v3.0.0-Beta-2.yaml
@@ -33,6 +33,9 @@ info:
     Please also [create a GitHub
     issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any
     questions/comments.
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
   contact:
     name: Digital Container Shipping Association (DCSA)
     url: 'https://dcsa.org'
@@ -88,6 +91,7 @@ paths:
                   type: org.dcsa.shipping-instructions-notification.v3
                   time: '2018-04-05T17:31:00Z'
                   datacontenttype: application/json
+                  subscriptionReference: SI001
                   data:
                     shippingInstructionsStatus: RECEIVED
                     shippingInstructionsReference: e0559d83-00e2-438e-afd9-fdd610c1a008
@@ -107,6 +111,7 @@ paths:
                   type: org.dcsa.shipping-instructions-notification.v3
                   time: '2018-04-05T17:31:00Z'
                   datacontenttype: application/json
+                  subscriptionReference: SI001
                   data:
                     shippingInstructionsStatus: PENDING UPDATE
                     updatedShippingInstructionsStatus: UPDATE DECLINED
@@ -169,6 +174,7 @@ paths:
                   type: org.dcsa.transport-document-notification.v3
                   time: '2018-04-05T17:31:00Z'
                   datacontenttype: application/json
+                  subscriptionReference: EBL001
                   data:
                     transportDocumentStatus: DRAFT
                     transportDocumentReference: HHL71800000
@@ -185,6 +191,7 @@ paths:
                   type: org.dcsa.transport-document-notification.v3
                   time: '2018-04-05T17:31:00Z'
                   datacontenttype: application/json
+                  subscriptionReference: EBL001
                   data:
                     transportDocumentStatus: ISSUED
                     transportDocumentReference: HHL71800000
@@ -323,6 +330,13 @@ components:
           enum:
             - application/json
           example: application/json
+        subscriptionReference:
+          type: string
+          pattern: ^\S+(\s+\S+)*$
+          maxLength: 100
+          description: >
+            The reference of the subscription that has triggered this event
+          example: '30675492-50ff-4e17-a7df-7a487a8ad343'
         data:
           type: object
           description: |
@@ -532,6 +546,13 @@ components:
           enum:
             - application/json
           example: application/json
+        subscriptionReference:
+          type: string
+          pattern: ^\S+(\s+\S+)*$
+          maxLength: 100
+          description: >
+            The reference of the subscription that has triggered this event
+          example: '30675492-50ff-4e17-a7df-7a487a8ad343'
         data:
           type: object
           description: |

--- a/ebl/v3/notification/EBL_NTF_v3.0.0-Beta-2.yaml
+++ b/ebl/v3/notification/EBL_NTF_v3.0.0-Beta-2.yaml
@@ -425,6 +425,7 @@ components:
         - type
         - time
         - datacontenttype
+        - subscriptionReference
         - data
     TransportDocumentNotification:
       type: object
@@ -621,4 +622,5 @@ components:
         - type
         - time
         - datacontenttype
+        - subscriptionReference
         - data


### PR DESCRIPTION
Add `subscriptionReference` to CloudEvent root level.
Update examples
Add missing API license text (copied from Booking license)