### PR TITLE
Update documentParties to reflect IFS

### DIFF
--- a/bkg/v2/BKG_v2.0.0-Beta-2.yaml
+++ b/bkg/v2/BKG_v2.0.0-Beta-2.yaml
@@ -1496,7 +1496,7 @@ paths:
                           streetNumber: '40'
                           postCode: '27568'
                           city: Bremerhaven
-                          country: DE
+                          countryCode: DE
                         partyContactDetails:
                           - name: Export operations department
                             phone: +49 471 945410
@@ -1586,7 +1586,7 @@ paths:
                           streetNumber: '40'
                           postCode: '27568'
                           city: Bremerhaven
-                          country: DE
+                          countryCode: DE
                         partyContactDetails:
                           - name: Export operations department
                             phone: +49 471 945410
@@ -2922,13 +2922,13 @@ components:
             All `Parties` with associated roles.
           properties:
             bookingAgent:
-              $ref: '#/components/schemas/BookingAgent'
+              $ref: '#/components/schemas/BookingAgent2'
             shipper:
-              $ref: '#/components/schemas/Shipper'
+              $ref: '#/components/schemas/Shipper2'
             consignee:
-              $ref: '#/components/schemas/Consignee'
+              $ref: '#/components/schemas/Consignee2'
             serviceContractOwner:
-              $ref: '#/components/schemas/ServiceContractOwner'
+              $ref: '#/components/schemas/ServiceContractOwner2'
             carrierBookingOffice:
               $ref: '#/components/schemas/CarrierBookingOffice'
             other:
@@ -3476,13 +3476,13 @@ components:
             All `Parties` with associated roles.
           properties:
             bookingAgent:
-              $ref: '#/components/schemas/BookingAgent'
+              $ref: '#/components/schemas/BookingAgent2'
             shipper:
-              $ref: '#/components/schemas/Shipper'
+              $ref: '#/components/schemas/Shipper2'
             consignee:
-              $ref: '#/components/schemas/Consignee'
+              $ref: '#/components/schemas/Consignee2'
             serviceContractOwner:
-              $ref: '#/components/schemas/ServiceContractOwner'
+              $ref: '#/components/schemas/ServiceContractOwner2'
             carrierBookingOffice:
               $ref: '#/components/schemas/CarrierBookingOffice'
             other:
@@ -4092,13 +4092,13 @@ components:
             All `Parties` with associated roles.
           properties:
             bookingAgent:
-              $ref: '#/components/schemas/BookingAgent'
+              $ref: '#/components/schemas/BookingAgent1'
             shipper:
-              $ref: '#/components/schemas/Shipper'
+              $ref: '#/components/schemas/Shipper1'
             consignee:
-              $ref: '#/components/schemas/Consignee'
+              $ref: '#/components/schemas/Consignee1'
             serviceContractOwner:
-              $ref: '#/components/schemas/ServiceContractOwner'
+              $ref: '#/components/schemas/ServiceContractOwner1'
             carrierBookingOffice:
               $ref: '#/components/schemas/CarrierBookingOffice'
             other:
@@ -4524,6 +4524,136 @@ components:
     # Document Parties
     ##################
 
+    PartyAddress1:
+      type: object
+      title: Address (with optional properties)
+      description: |
+        An object for storing address related information
+      properties:
+        street:
+          type: string
+          maxLength: 100
+          description: The name of the street of the party’s address.
+          example: Ruijggoordweg
+        streetNumber:
+          type: string
+          maxLength: 50
+          description: The number of the street of the party’s address.
+          example: '100'
+        floor:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 50
+          description: |
+            The floor of the party’s street number.
+          example: N/A
+        postCode:
+          type: string
+          maxLength: 50
+          description: The post code of the party’s address.
+          example: 1047 HM
+        city:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 65
+          description: |
+            The city name of the party’s address.
+          example: Amsterdam
+        UNLocationCode:
+          type: string
+          pattern: '^[A-Z]{2}[A-Z2-9]{3}$'
+          minLength: 5
+          maxLength: 5
+          description: |
+            The UN Location code specifying where the carrier booking office is located. The pattern used must be
+
+            - 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+            - 3 characters to code a location within that country. Letters A-Z and numbers from 2-9 can be used
+
+            More info can be found here: [UN/LOCODE](https://unece.org/trade/cefact/UNLOCODE-Download)
+          example: NLAMS
+        stateRegion:
+          type: string
+          maxLength: 65
+          description: The state/region of the party’s address.
+          nullable: true
+          example: North Holland
+        countryCode:
+          type: string
+          pattern: '^[A-Z]{2}$'
+          minLength: 2
+          maxLength: 2
+          description: |
+            The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+          example: NL
+      required:
+        - street
+        - streetNumber
+        - city
+        - countryCode
+    PartyAddress2:
+      type: object
+      title: Address (with required properties)
+      description: |
+        An object for storing address related information
+      properties:
+        street:
+          type: string
+          maxLength: 100
+          description: The name of the street of the party’s address.
+          example: Ruijggoordweg
+        streetNumber:
+          type: string
+          maxLength: 50
+          description: The number of the street of the party’s address.
+          example: '100'
+        floor:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 50
+          description: |
+            The floor of the party’s street number.
+          example: N/A
+        postCode:
+          type: string
+          maxLength: 50
+          description: The post code of the party’s address.
+          example: 1047 HM
+        city:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 65
+          description: |
+            The city name of the party’s address.
+          example: Amsterdam
+        UNLocationCode:
+          type: string
+          pattern: '^[A-Z]{2}[A-Z2-9]{3}$'
+          minLength: 5
+          maxLength: 5
+          description: |
+            The UN Location code specifying where the carrier booking office is located. The pattern used must be
+
+            - 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+            - 3 characters to code a location within that country. Letters A-Z and numbers from 2-9 can be used
+
+            More info can be found here: [UN/LOCODE](https://unece.org/trade/cefact/UNLOCODE-Download)
+          example: NLAMS
+        stateRegion:
+          type: string
+          maxLength: 65
+          description: The state/region of the party’s address.
+          nullable: true
+          example: North Holland
+        countryCode:
+          type: string
+          pattern: '^[A-Z]{2}$'
+          minLength: 2
+          maxLength: 2
+          description: |
+            The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+          example: NL
+
     OtherDocumentParty:
       type: object
       title: Other Document Party
@@ -4531,7 +4661,7 @@ components:
         A list of document parties that can be optionally provided at booking stage
       properties:
         party:
-          $ref: '#/components/schemas/Party'
+          $ref: '#/components/schemas/Party2'
         partyFunction:
           type: string
           maxLength: 3
@@ -4550,9 +4680,9 @@ components:
         - party
         - partyFunction
 
-    BookingAgent:
+    BookingAgent1:
       type: object
-      title: Booking Agent
+      title: Booking Agent (with optional Address properties)
       description: |
         The party placing the booking request on behalf of the customer.
       properties:
@@ -4564,7 +4694,7 @@ components:
             Name of the party.
           example: IKEA Denmark
         address:
-          $ref: '#/components/schemas/Address'
+          $ref: '#/components/schemas/PartyAddress1'
         partyContactDetails:
           type: array
           minItems: 1
@@ -4573,6 +4703,7 @@ components:
           items:
             $ref: '#/components/schemas/PartyContactDetail'
         identifyingCodes:
+          title: Identifying Codes
           type: array
           items:
             $ref: '#/components/schemas/IdentifyingCode'
@@ -4585,9 +4716,57 @@ components:
       required:
         - partyName
 
-    Shipper:
+    BookingAgent2:
       type: object
-      title: Shipper
+      title: Booking Agent (with required Address properties)
+      description: |
+        The party placing the booking request on behalf of the customer.
+
+        **Conditional:** Either an `address` or an `identifyingCode` MUST be provided.
+      properties:
+        partyName:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            Name of the party.
+          example: IKEA Denmark
+        partyContactDetails:
+          type: array
+          minItems: 1
+          description: |
+            A list of contact details
+          items:
+            $ref: '#/components/schemas/PartyContactDetail'
+        taxLegalReferences:
+          description: |
+            A list of `Tax References` for a `Party`
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxLegalReference'
+      oneOf:
+        - type: object
+          properties:
+            address:
+              $ref: '#/components/schemas/PartyAddress2'
+          required:
+            - address
+        - type: object
+          properties:
+            identifyingCodes:
+              title: Identifying Codes
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/IdentifyingCode'
+          required:
+            - identifyingCodes
+      required:
+        - partyName
+
+    Shipper1:
+      type: object
+      title: Shipper (with optional Address properties)
       description: |
         The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
       properties:
@@ -4620,9 +4799,57 @@ components:
       required:
         - partyName
 
-    Consignee:
+    Shipper2:
       type: object
-      title: Consignee
+      title: Shipper (with required Address properties)
+      description: |
+        The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
+
+        **Conditional:** Either an `address` or an `identifyingCode` MUST be provided.
+      properties:
+        partyName:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            Name of the party.
+          example: IKEA Denmark
+        partyContactDetails:
+          type: array
+          minItems: 1
+          description: |
+            A list of contact details
+          items:
+            $ref: '#/components/schemas/PartyContactDetail'
+        taxLegalReferences:
+          description: |
+            A list of `Tax References` for a `Party`
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxLegalReference'
+      oneOf:
+        - type: object
+          properties:
+            address:
+              $ref: '#/components/schemas/PartyAddress2'
+          required:
+            - address
+        - type: object
+          properties:
+            identifyingCodes:
+              title: Identifying Codes
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/IdentifyingCode'
+          required:
+            - identifyingCodes
+      required:
+        - partyName
+
+    Consignee1:
+      type: object
+      title: Consignee (with optional Address properties)
       description: |
         The party to which goods are consigned in the Master Bill of Lading.
       properties:
@@ -4655,9 +4882,57 @@ components:
       required:
         - partyName
 
-    ServiceContractOwner:
+    Consignee2:
       type: object
-      title: Service Contract Owner
+      title: Consignee (with required Address properties)
+      description: |
+        The party to which goods are consigned in the Master Bill of Lading.
+
+        **Conditional:** Either an `address` or an `identifyingCode` MUST be provided.
+      properties:
+        partyName:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            Name of the party.
+          example: IKEA Denmark
+        partyContactDetails:
+          type: array
+          minItems: 1
+          description: |
+            A list of contact details
+          items:
+            $ref: '#/components/schemas/PartyContactDetail'
+        taxLegalReferences:
+          description: |
+            A list of `Tax References` for a `Party`
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxLegalReference'
+      oneOf:
+        - type: object
+          properties:
+            address:
+              $ref: '#/components/schemas/PartyAddress2'
+          required:
+            - address
+        - type: object
+          properties:
+            identifyingCodes:
+              title: Identifying Codes
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/IdentifyingCode'
+          required:
+            - identifyingCodes
+      required:
+        - partyName
+
+    ServiceContractOwner1:
+      type: object
+      title: Service Contract Owner (with optional Address properties)
       description: |
         The party signing the service contract with the carrier.
       properties:
@@ -4687,6 +4962,54 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TaxLegalReference'
+      required:
+        - partyName
+
+    ServiceContractOwner2:
+      type: object
+      title: Service Contract Owner (with required Address properties)
+      description: |
+        The party signing the service contract with the carrier.
+
+        **Conditional:** Either an `address` or an `identifyingCode` MUST be provided.
+      properties:
+        partyName:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            Name of the party.
+          example: IKEA Denmark
+        partyContactDetails:
+          type: array
+          minItems: 1
+          description: |
+            A list of contact details
+          items:
+            $ref: '#/components/schemas/PartyContactDetail'
+        taxLegalReferences:
+          description: |
+            A list of `Tax References` for a `Party`
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxLegalReference'
+      oneOf:
+        - type: object
+          properties:
+            address:
+              $ref: '#/components/schemas/PartyAddress2'
+          required:
+            - address
+        - type: object
+          properties:
+            identifyingCodes:
+              title: Identifying Codes
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/IdentifyingCode'
+          required:
+            - identifyingCodes
       required:
         - partyName
 
@@ -4744,6 +5067,41 @@ components:
           example: IKEA Denmark
         address:
           $ref: '#/components/schemas/Address'
+        partyContactDetails:
+          type: array
+          minItems: 1
+          description: |
+            A list of contact details
+          items:
+            $ref: '#/components/schemas/PartyContactDetail'
+        identifyingCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentifyingCode'
+        taxLegalReferences:
+          description: |
+            A list of `Tax References` for a `Party`
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxLegalReference'
+      required:
+        - partyName
+
+    Party2:
+      type: object
+      title: Party (with required Address properties)
+      description: |
+        Refers to a company or a legal entity.
+      properties:
+        partyName:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            Name of the party.
+          example: IKEA Denmark
+        address:
+          $ref: '#/components/schemas/PartyAddress2'
         partyContactDetails:
           type: array
           minItems: 1

--- a/bkg/v2/BKG_v2.0.0-Beta-2.yaml
+++ b/bkg/v2/BKG_v2.0.0-Beta-2.yaml
@@ -4546,7 +4546,7 @@ components:
           maxLength: 50
           description: |
             The floor of the party’s street number.
-          example: N/A
+          example: 2nd
         postCode:
           type: string
           maxLength: 50


### PR DESCRIPTION
Updated the specs as discussed in the meeting (and on Teams):
- fixed an example bug (country --> countryCode)
- added UNLocation to the address in Party-objects
- made sure there is a difference between POST, PUT and GET with regards to documentParies
  - in POST and PUT 4 fields in the address object is required
  - made sure there is a oneOf between Address and IndentifyingCodes

We should evaluate if the extra 350+ lines of code justifies the above...