### PR TITLE
DT-1189: Add missing title property (and remove title from reason)

### DIFF
--- a/bkg/v2/BKG_v2.0.0-Beta-3.yaml
+++ b/bkg/v2/BKG_v2.0.0-Beta-3.yaml
@@ -2182,6 +2182,7 @@ components:
           example: PRE
         originChargesPaymentTerm:
           type: object
+          title: Origin Charges Payment Term
           description: |
             An indicator of whether origin charges are prepaid (`PRE`) or collect (`COL`). When prepaid, the charges are the responsibility of the shipper or the Invoice payer on behalf of the shipper (if provided). When collect, the charges are the responsibility of the consignee or the Invoice payer on behalf of the consignee (if provided).
           properties:
@@ -2220,6 +2221,7 @@ components:
               example: PRE
         destinationChargesPaymentTerm:
           type: object
+          title: Destination Charges Payment Term
           description: |
             An indicator of whether destination charges are prepaid (`PRE`) or collect (`COL`). When prepaid, the charges are the responsibility of the shipper or the Invoice payer on behalf of the shipper (if provided). When collect, the charges are the responsibility of the consignee or the Invoice payer on behalf of the consignee (if provided).
           properties:
@@ -2570,6 +2572,7 @@ components:
             $ref: '#/components/schemas/Reference'
         documentParties:
           type: object
+          title: Document Parties
           description: |
             All `Parties` with associated roles.
           properties:
@@ -2733,6 +2736,7 @@ components:
           example: PRE
         originChargesPaymentTerm:
           type: object
+          title: Origin Charges Payment Term
           description: |
             An indicator of whether origin charges are prepaid (`PRE`) or collect (`COL`). When prepaid, the charges are the responsibility of the shipper or the Invoice payer on behalf of the shipper (if provided). When collect, the charges are the responsibility of the consignee or the Invoice payer on behalf of the consignee (if provided).
           properties:
@@ -2771,6 +2775,7 @@ components:
               example: PRE
         destinationChargesPaymentTerm:
           type: object
+          title: Destination Charges Payment Term
           description: |
             An indicator of whether destination charges are prepaid (`PRE`) or collect (`COL`). When prepaid, the charges are the responsibility of the shipper or the Invoice payer on behalf of the shipper (if provided). When collect, the charges are the responsibility of the consignee or the Invoice payer on behalf of the consignee (if provided).
           properties:
@@ -3124,6 +3129,7 @@ components:
             $ref: '#/components/schemas/Reference'
         documentParties:
           type: object
+          title: Document Parties
           description: |
             All `Parties` with associated roles.
           properties:
@@ -3344,6 +3350,7 @@ components:
           example: PRE
         originChargesPaymentTerm:
           type: object
+          title: Origin Charges Payment Term
           description: |
             An indicator of whether origin charges are prepaid (`PRE`) or collect (`COL`). When prepaid, the charges are the responsibility of the shipper or the Invoice payer on behalf of the shipper (if provided). When collect, the charges are the responsibility of the consignee or the Invoice payer on behalf of the consignee (if provided).
           properties:
@@ -3382,6 +3389,7 @@ components:
               example: PRE
         destinationChargesPaymentTerm:
           type: object
+          title: Destination Charges Payment Term
           description: |
             An indicator of whether destination charges are prepaid (`PRE`) or collect (`COL`). When prepaid, the charges are the responsibility of the shipper or the Invoice payer on behalf of the shipper (if provided). When collect, the charges are the responsibility of the consignee or the Invoice payer on behalf of the consignee (if provided).
           properties:
@@ -3740,6 +3748,7 @@ components:
             $ref: '#/components/schemas/Reference'
         documentParties:
           type: object
+          title: Document Parties
           description: |
             All `Parties` with associated roles.
           properties:
@@ -3857,7 +3866,6 @@ components:
             $ref: '#/components/schemas/RequestedChange'
         reason:
           type: string
-          title: reason
           maxLength: 5000
           description: >
             This field can be used to explain `bookingStatus` and/or
@@ -3969,7 +3977,6 @@ components:
             $ref: '#/components/schemas/RequestedChange'
         reason:
           type: string
-          title: reason
           maxLength: 5000
           description: >
             This field can be used to explain `bookingStatus` and/or
@@ -4039,7 +4046,6 @@ components:
           example: AMENDMENT CANCELLED
         reason:
           type: string
-          title: reason
           maxLength: 5000
           description: >
             This field can be used to explain `bookingStatus` and/or
@@ -4178,7 +4184,7 @@ components:
 
     PartyAddress:
       type: object
-      title: Address
+      title: Party Address
       description: |
         An object for storing address related information
       properties:
@@ -4815,12 +4821,12 @@ components:
             type.
           example: false
         activeReeferSettings:
-          description: >
+          type: object
+          title: Active Reefer Settings
+          description: |
             The specifications for a Reefer equipment.
 
-
-            **Condition:** Only applicable when `isNonOperatingReefer` is set to
-            `false`
+            **Condition:** Only applicable when `isNonOperatingReefer` is set to `false`
           allOf:
             - $ref: '#/components/schemas/ActiveReeferSettings'
           required:
@@ -5414,6 +5420,7 @@ components:
           example: A
         grossWeight:
           type: object
+          title: Gross Weight
           description: |
             Total weight of the goods carried, including packaging.
           properties:
@@ -5423,19 +5430,13 @@ components:
               example: 12000.3
               minimum: 0
               exclusiveMinimum: true
-              description: >
-                The grand total weight of the DG cargo and weight per
-                UNNumber/NANumber including packaging items being carried, which
-                can be expressed in imperial or metric terms, as provided by the
-                shipper.
+              description: |
+                The grand total weight of the DG cargo and weight per `UNNumber`/`NANumber` including packaging items being carried, which can be expressed in imperial or metric terms, as provided by the shipper.
             unit:
               type: string
-              description: >
-                The unit of measure which can be expressed in imperial or metric
-                terms
-
+              description: |
+                The unit of measure which can be expressed in imperial or metric terms
                 - `KGM` (Kilograms)
-
                 - `LBR` (Pounds)
               enum:
                 - KGM
@@ -5446,6 +5447,7 @@ components:
             - unit
         netWeight:
           type: object
+          title: Net Weight
           description: |
             Total weight of the goods carried, excluding packaging.
           properties:
@@ -5457,12 +5459,9 @@ components:
               example: 2.4
             unit:
               type: string
-              description: >
-                Unit of measure used to describe the `netWeight`. Possible
-                values are
-
+              description: |
+                Unit of measure used to describe the `netWeight`. Possible values are
                 - `KGM` (Kilograms)
-
                 - `LBR` (Pounds)
               enum:
                 - KGM
@@ -5473,25 +5472,21 @@ components:
             - unit
         netExplosiveContent:
           type: object
-          description: >
-            The total weight of the explosive substances, without the
-            packaging’s, casings, etc.
+          title: Net Explosive Content
+          description: |
+            The total weight of the explosive substances, without the packaging's, casings, etc.
           properties:
             value:
               type: number
               format: float
-              description: >
-                The total weight of the explosive substances, without the
-                packaging’s, casings, etc.
+              description: |
+                The total weight of the explosive substances, without the packaging's, casings, etc.
               example: 2.4
             unit:
               type: string
-              description: >
-                Unit of measure used to describe the `netExplosiveWeight`.
-                Possible values are
-
+              description: |
+                Unit of measure used to describe the `netExplosiveWeight`. Possible values are
                 - `KGM` (Kilograms)
-
                 - `GRM` (Grams)
               enum:
                 - KGM
@@ -5502,6 +5497,7 @@ components:
             - unit
         volume:
           type: object
+          title: Volume
           description: |
             The volume of the referenced dangerous goods.
 
@@ -5515,14 +5511,10 @@ components:
               example: 2.4
             unit:
               type: string
-              description: >
-                The unit of measure which can be expressed in either imperial or
-                metric terms
-
+              description: |
+                The unit of measure which can be expressed in either imperial or metric terms
                 - `FTQ` (Cubic foot)
-
                 - `MTQ` (Cubic meter)
-
                 - `LTR` (Litre)
               enum:
                 - MTQ
@@ -5628,6 +5620,7 @@ components:
         - phone
     Limits:
       type: object
+      title: Limits
       description: >
         Limits for the `Dangerous Goods`. The same `Temperature Unit` needs to
         apply to all attributes in this structure.
@@ -5719,19 +5712,16 @@ components:
       ###########
     Transport:
       type: object
+      title: Transport
       description: |
         A single `leg` of the `Transport Plan`
       properties:
         transportPlanStage:
           type: string
-          description: >
-            Code qualifying a specific stage of transport e.g. pre-carriage,
-            main carriage transport or on-carriage transport
-
+          description: |
+            Code qualifying a specific stage of transport e.g. pre-carriage, main carriage transport or on-carriage transport
             - `PRC` (Pre-Carriage)
-
             - `MNC` (Main Carriage Transport)
-
             - `ONC` (On-Carriage Transport)
           enum:
             - PRC
@@ -6012,6 +6002,7 @@ components:
       ########
     Charge:
       type: object
+      title: Charge
       description: >
         Addresses the monetary value of freight and other service charges for a
         `Booking`.


### PR DESCRIPTION
Added `title` properties to all objects defined
Removed `title` property on the `reason` simpleType (it is not an object)
Improved a few descriptions that stoplight had "automodified" near places I anyhow modified