### PR TITLE
DT-1152: Add volumeUnit being conditional on volume

### DIFF
--- a/ebl/v3/EBL_v3.0.0-Beta-3.yaml
+++ b/ebl/v3/EBL_v3.0.0-Beta-3.yaml
@@ -4068,6 +4068,8 @@ components:
             The unit of measure which can be expressed in either imperial or metric terms
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
+
+            **Condition:** Mandatory to provide if `volume` is provided
           enum:
             - MTQ
             - FTQ
@@ -4134,6 +4136,8 @@ components:
             The unit of measure which can be expressed in either imperial or metric terms
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
+
+            **Condition:** Mandatory to provide if `volume` is provided
           enum:
             - MTQ
             - FTQ

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0-Beta-3.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0-Beta-3.yaml
@@ -1108,6 +1108,8 @@ components:
             The unit of measure which can be expressed in either imperial or metric terms
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
+
+            **Condition:** Mandatory to provide if `volume` is provided
           enum:
             - MTQ
             - FTQ

--- a/pint/v3/EBL_PINT_v3.0.0-Beta-3.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0-Beta-3.yaml
@@ -1642,6 +1642,8 @@ components:
             The unit of measure which can be expressed in either imperial or metric terms
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
+
+            **Condition:** Mandatory to provide if `volume` is provided
           enum:
             - MTQ
             - FTQ


### PR DESCRIPTION
Only add it as part of the description as the `volume` property is optional and `volumeUnit` is only mandatory **IF** `volume` is provided