### PR TITLE
DT-1165: Remove minItems on optional arrays

### DIFF
--- a/ebl/v3/EBL_v3.0.0-Beta-3.yaml
+++ b/ebl/v3/EBL_v3.0.0-Beta-3.yaml
@@ -1951,7 +1951,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Receipt` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -1962,7 +1961,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -1973,7 +1971,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -1984,7 +1981,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2307,7 +2303,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Receipt` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2318,7 +2313,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2329,7 +2323,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2340,7 +2333,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2690,7 +2682,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Receipt` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2701,7 +2692,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2712,7 +2702,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -2723,7 +2712,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -5202,7 +5190,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Receipt` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -5213,7 +5200,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -5224,7 +5210,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -5235,7 +5220,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0-Beta-3.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0-Beta-3.yaml
@@ -496,7 +496,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Receipt` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -507,7 +506,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -518,7 +516,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -529,7 +526,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string

--- a/pint/v3/EBL_PINT_v3.0.0-Beta-3.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0-Beta-3.yaml
@@ -1030,7 +1030,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Receipt` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -1041,7 +1040,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -1052,7 +1050,6 @@ components:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string
@@ -1063,7 +1060,6 @@ components:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
           type: array
-          minItems: 1
           maxItems: 5
           items:
             type: string


### PR DESCRIPTION
Since the `displayedNameFor...` properties are optional - then minItems=1 should be removed as it is allowed not to provide any items...