### PR TITLE
DT-1187: Add imperial units to netExplosiveContent

### DIFF
--- a/an/v1/AN_v1.0.0-Beta-1.yaml
+++ b/an/v1/AN_v1.0.0-Beta-1.yaml
@@ -2173,10 +2173,14 @@ components:
                 Unit of measure used to describe the `netExplosiveWeight`. Possible values are
 
                 - `KGM` (Kilograms)
+                - `LBR` (Pounds)
                 - `GRM` (Grams)
+                - `ONZ` (Ounce)
               enum:
                 - KGM
+                - LBR
                 - GRM
+                - ONZ
               example: KGM
           required:
             - value

--- a/bkg/v2/BKG_v2.0.0-Beta-3.yaml
+++ b/bkg/v2/BKG_v2.0.0-Beta-3.yaml
@@ -4920,10 +4920,14 @@ components:
               description: |
                 Unit of measure used to describe the `netExplosiveWeight`. Possible values are
                 - `KGM` (Kilograms)
+                - `LBR` (Pounds)
                 - `GRM` (Grams)
+                - `ONZ` (Ounce)
               enum:
                 - KGM
+                - LBR
                 - GRM
+                - ONZ
               example: KGM
           required:
             - value

--- a/ebl/v3/EBL_v3.0.0-Beta-3.yaml
+++ b/ebl/v3/EBL_v3.0.0-Beta-3.yaml
@@ -4508,10 +4508,14 @@ components:
                 Unit of measure used to describe the `netExplosiveWeight`. Possible values are
 
                 - `KGM` (Kilograms)
+                - `LBR` (Pounds)
                 - `GRM` (Grams)
+                - `ONZ` (Ounce)
               enum:
                 - KGM
+                - LBR
                 - GRM
+                - ONZ
               example: KGM
           required:
             - value

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0-Beta-3.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0-Beta-3.yaml
@@ -1469,10 +1469,14 @@ components:
                 Unit of measure used to describe the `netExplosiveWeight`. Possible values are
 
                 - `KGM` (Kilograms)
+                - `LBR` (Pounds)
                 - `GRM` (Grams)
+                - `ONZ` (Ounce)
               enum:
                 - KGM
+                - LBR
                 - GRM
+                - ONZ
               example: KGM
           required:
             - value

--- a/pint/v3/EBL_PINT_v3.0.0-Beta-3.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0-Beta-3.yaml
@@ -2003,10 +2003,14 @@ components:
                 Unit of measure used to describe the `netExplosiveWeight`. Possible values are
 
                 - `KGM` (Kilograms)
+                - `LBR` (Pounds)
                 - `GRM` (Grams)
+                - `ONZ` (Ounce)
               enum:
                 - KGM
+                - LBR
                 - GRM
+                - ONZ
               example: KGM
           required:
             - value


### PR DESCRIPTION
Imperial units are missing on the `netExplosiveContent` peroperty in DG (DangerousGoods). Adding here for consistency as we have imperial units on **all** other units