### PR TITLE
DT-1188: Fix some of the BKG Spectral errors

### DIFF
--- a/bkg/v2/BKG_v2.0.0-Beta-3.yaml
+++ b/bkg/v2/BKG_v2.0.0-Beta-3.yaml
@@ -385,8 +385,7 @@ paths:
                       ISOEquipmentCode: 42GP
                       units: 3
                       commodities:
-                        - commodityType: |
-                            Environmentally hazardous substance, liquid, N.O.S (Propiconazole)
+                        - commodityType: 'Environmentally hazardous substance, liquid, N.O.S (Propiconazole)'
                           HSCodes:
                             - '293499'
                           cargoGrossWeight: 36000
@@ -958,8 +957,7 @@ paths:
                       ISOEquipmentCode: 42GP
                       units: 3
                       commodities:
-                        - commodityType: |
-                            Environmentally hazardous substance, liquid, N.O.S (Propiconazole)
+                        - commodityType: 'Environmentally hazardous substance, liquid, N.O.S (Propiconazole)'
                           HSCodes:
                             - '293499'
                           cargoGrossWeight: 36000
@@ -2790,7 +2788,7 @@ components:
           example: true
         importLicenseReference:
           maxLength: 35
-          pattern: '^\S+(\s+\S+)*$'
+          pattern: '^\S(?:.*\S)?$'
           type: string
           description: |
             A certificate, issued by countries exercising import controls, that permits importation of the articles stated in the license. Reference number assigned by an issuing authority to an Import License. The import license number must be valid at time of arrival. Required if import license required is ‘True’.
@@ -2988,13 +2986,13 @@ components:
         - deliveryTypeAtDestination
         - cargoMovementTypeAtOrigin
         - cargoMovementTypeAtDestination
-        - requestedEquipments
         - isPartialLoadAllowed
         - isExportDeclarationRequired
         - isImportLicenseRequired
         - communicationChannelCode
         - isEquipmentSubstitutionAllowed
         - shipmentLocations
+        - requestedEquipments
         - documentParties
 
     ###############
@@ -3290,7 +3288,7 @@ components:
           example: true
         importLicenseReference:
           maxLength: 35
-          pattern: '^\S+(\s+\S+)*$'
+          pattern: '^\S(?:.*\S)?$'
           type: string
           description: |
             A certificate, issued by countries exercising import controls, that permits importation of the articles stated in the license. Reference number assigned by an issuing authority to an Import License. The import license number must be valid at time of arrival. Required if import license required is ‘True’.
@@ -3552,13 +3550,13 @@ components:
         - deliveryTypeAtDestination
         - cargoMovementTypeAtOrigin
         - cargoMovementTypeAtDestination
-        - requestedEquipments
         - isPartialLoadAllowed
         - isExportDeclarationRequired
         - isImportLicenseRequired
         - communicationChannelCode
         - isEquipmentSubstitutionAllowed
         - shipmentLocations
+        - requestedEquipments
         - documentParties
 
     #########################
@@ -4699,6 +4697,7 @@ components:
           maxLength: 250
           description: |
             The recognized chemical or biological name or other name currently used for the referenced dangerous goods as described in chapter 3.1.2.8 of the IMDG Code.
+          example: 'xylene and benzene'
         imoClass:
           type: string
           maxLength: 4
@@ -5265,6 +5264,7 @@ components:
         - plannedDepartureDate
         - plannedArrivalDate
     LoadLocation:
+      type: object
       title: Load Location
       description: |
         General purpose object to capture the `Load Location`.
@@ -5287,6 +5287,7 @@ components:
           FACI: '#/components/schemas/FacilityLocation'
           UNLO: '#/components/schemas/UNLocationLocation'
     DischargeLocation:
+      type: object
       title: Discharge Location
       description: |
         General purpose object to capture the `Discharge Location`.


### PR DESCRIPTION
There are still some items left in the error tab:
* all errors related to `oneOf`, `anyOf` or `allOf` as this needs to be fixed in Spectral (not supported yet) - this shows up as a problem for UNLocationCode and countryCode
* The required fields on Address and PartyAddress have been fixed in the Spectral rules (in another PR)
* postCode maxLength has been changed to 10 in another PR
* all objects with discriminators need to be fixed in Spectral (not supported yet)
* unit enum needs to be fixed in Spectral (not supported yet - will be fixed in another PR)
* $ref link on ActiveReeferSettings needs to be fixed in Spectral (not supported yet - will be fixed in another PR)

This PR fixed the following Spectral errors:
* catastrophic backtracking on importLicenseRefernce
* wrong order of required fields (order must match Spectral rule)
* DT technicalName must have an example
* type=object was missing 2 places

This PR also fixed StopLight complaining that an example was formatted wrong (fixed for convenience)