### PR TITLE
Fixed errorDatetime example

### DIFF
--- a/ovs/v3/OVS_v3.0.1.yaml
+++ b/ovs/v3/OVS_v3.0.1.yaml
@@ -641,7 +641,7 @@ components:
             The DateTime corresponding to the error occuring. Must be formatted using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
           type: string
           format: date-time
-          example: '2019-11-12T07:41:00+08:30'
+          example: '2019-11-12T07:41:00Z'
         errors:
           type: array
           description: |


### PR DESCRIPTION
Changed errorDateTime example to UTC for OVS_3.0.1