### PR TITLE
DT-1257: Remove ECR and BID from EBL ReferenceType

### DIFF
--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -3926,9 +3926,7 @@ components:
           description: |
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer’s Reference)
-            - `ECR` (Empty container release reference)
             - `CSI` (Customer shipment ID)
-            - `BID` (Booking Request ID)
             - `SAC` (Shipping Agency Code)
           example: CR
         value:

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -913,9 +913,7 @@ components:
           description: |
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer’s Reference)
-            - `ECR` (Empty container release reference)
             - `CSI` (Customer shipment ID)
-            - `BID` (Booking Request ID)
             - `SAC` (Shipping Agency Code)
           example: CR
         value:

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1452,9 +1452,7 @@ components:
           description: |
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer’s Reference)
-            - `ECR` (Empty container release reference)
             - `CSI` (Customer shipment ID)
-            - `BID` (Booking Request ID)
             - `SAC` (Shipping Agency Code)
           example: CR
         value:


### PR DESCRIPTION
Remove ECR (Empty Container Release) and BID (Booking Request ID) from the EBL references [DT-1257](https://dcsa.atlassian.net/browse/DT-1257)

[DT-1257]: https://dcsa.atlassian.net/browse/DT-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ