### PR TITLE
DT-1316: Update references

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -4285,9 +4285,8 @@ components:
           description: |
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer's Reference)
-            - `CSI` (Customer shipment ID)
-            - `BID` (Booking Request ID)
-            - `SAC` (Shipping Agency Code)
+            - `AKG` (Vehicle Identification Number)
+            - `AEF` (Customer Load Reference)
           example: CR
         value:
           type: string
@@ -4312,9 +4311,8 @@ components:
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer's Reference)
             - `ECR` (Empty container release reference)
-            - `CSI` (Customer shipment ID)
-            - `BID` (Booking Request ID)
-            - `SAC` (Shipping Agency Code)
+            - `AKG` (Vehicle Identification Number)
+            - `AEF` (Customer Load Reference)
           example: CR
         value:
           type: string

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -3840,8 +3840,7 @@ components:
           description: |
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer’s Reference)
-            - `CSI` (Customer shipment ID)
-            - `SAC` (Shipping Agency Code)
+            - `AKG` (Vehicle Identification Number)
           example: CR
         value:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -917,8 +917,7 @@ components:
           description: |
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer’s Reference)
-            - `CSI` (Customer shipment ID)
-            - `SAC` (Shipping Agency Code)
+            - `AKG` (Vehicle Identification Number)
           example: CR
         value:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1456,8 +1456,7 @@ components:
           description: |
             The reference type codes defined by DCSA. Possible values are:
             - `CR` (Customer’s Reference)
-            - `CSI` (Customer shipment ID)
-            - `SAC` (Shipping Agency Code)
+            - `AKG` (Vehicle Identification Number)
           example: CR
         value:
           type: string


### PR DESCRIPTION
Update according to [DT-1316](https://dcsa.atlassian.net/browse/DT-1316):

1. Applicable to BKG & BL 
  a). Remove reference types SAC, BID, CSI. During DCSA week multiple carriers argued that some reference types should be removed since there is no use for them in the standards. After further discussion and clarifications in the DT SME meeting of July 1, 2024, the majority has agreed to remove the mentioned ones.
  b). Add AKG (Vehicle Identification Number) on the equipment and commodity level, defined as: A unique code used by the automotive industry to identify individual motor vehicles, towed vehicles, motorcycles, scooters and mopeds as defined in ISO 3779 and ISO 4030. 
2. Applicable to BKG
  a). Add AEF (Customer Load Reference) on the equipment level defined as: Retrieval number for a process specification defined by the customer. This reference is provided by the customer in case of carrier haulage at origin for the empty container positioning. It is typically used by the trucker to do the link with the equipment reference during the pick-up. In the same booking, there can be multiple references, one per container. Examples: from Sweden “RFF+AEF:VP381019'”, from Germany “RFF+AEF:AUF240610248”. 

[DT-1316]: https://dcsa.atlassian.net/browse/DT-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ