### PR TITLE
Remove name in Address examples

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -183,7 +183,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -251,7 +250,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -328,7 +326,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -396,7 +393,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -847,7 +843,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -917,7 +912,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -994,7 +988,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -1065,7 +1058,6 @@ paths:
                     bookingAgent:
                       partyName: KN Bremerhaven
                       address:
-                        name: Kuehne + Nagel (AG & Co.) KG
                         street: Amerikaring
                         streetNumber: '40'
                         postCode: '27568'
@@ -1439,7 +1431,6 @@ paths:
                       bookingAgent:
                         partyName: KN Bremerhaven
                         address:
-                          name: Kuehne + Nagel (AG & Co.) KG
                           street: Amerikaring
                           streetNumber: '40'
                           postCode: '27568'
@@ -1521,7 +1512,6 @@ paths:
                       bookingAgent:
                         partyName: KN Bremerhaven
                         address:
-                          name: Kuehne + Nagel (AG & Co.) KG
                           street: Amerikaring
                           streetNumber: '40'
                           postCode: '27568'
@@ -2236,7 +2226,6 @@ paths:
                         bookingAgent:
                           partyName: KN Bremerhaven
                           address:
-                            name: Kuehne + Nagel (AG & Co.) KG
                             street: Amerikaring
                             streetNumber: '40'
                             postCode: '27568'
@@ -2342,7 +2331,6 @@ paths:
                         bookingAgent:
                           partyName: KN Bremerhaven
                           address:
-                            name: Kuehne + Nagel (AG & Co.) KG
                             street: Amerikaring
                             streetNumber: '40'
                             postCode: '27568'
@@ -2444,7 +2432,6 @@ paths:
                         bookingAgent:
                           partyName: KN Bremerhaven
                           address:
-                            name: Kuehne + Nagel (AG & Co.) KG
                             street: Amerikaring
                             streetNumber: '40'
                             postCode: '27568'


### PR DESCRIPTION
Fix bug in Address object examples - `name` property is no longer part of the Address object