### PR TITLE
DT-1223: Add missing example value on displayedNameForXXX

### DIFF
--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -3269,6 +3269,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPortOfLoad:
                   description: |
                     The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -3280,6 +3284,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPortOfDischarge:
                   description: |
                     The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -3291,6 +3299,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPlaceOfDelivery:
                   description: |
                     The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -3302,6 +3314,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 placeOfIssue:
                   type: object
                   title: Place of Issue
@@ -3741,6 +3757,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPortOfLoad:
                   description: |
                     The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -3752,6 +3772,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPortOfDischarge:
                   description: |
                     The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -3763,6 +3787,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPlaceOfDelivery:
                   description: |
                     The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -3774,6 +3802,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 placeOfIssue:
                   type: object
                   title: Place of Issue
@@ -4215,6 +4247,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPortOfLoad:
                   description: |
                     The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -4226,6 +4262,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPortOfDischarge:
                   description: |
                     The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -4237,6 +4277,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 displayedNameForPlaceOfDelivery:
                   description: |
                     The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -4248,6 +4292,10 @@ components:
                     description: |
                       A line of the address to be displayed on the transport document.
                     example: 'Strawinskylaan 4117'
+                  example:
+                    - Strawinskylaan 457
+                    - 1077 XX Amsterdam
+                    - Nederlandene
                 shippedOnBoardDate:
                   type: string
                   format: date
@@ -4805,6 +4853,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfLoad:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -4816,6 +4868,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfDischarge:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -4827,6 +4883,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPlaceOfDelivery:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -4838,6 +4898,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         placeOfIssue:
           type: object
           title: Place of Issue
@@ -5237,6 +5301,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfLoad:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -5248,6 +5316,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfDischarge:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -5259,6 +5331,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPlaceOfDelivery:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -5270,6 +5346,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         placeOfIssue:
           type: object
           title: Place of Issue
@@ -5696,6 +5776,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfLoad:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -5707,6 +5791,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfDischarge:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -5718,6 +5806,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPlaceOfDelivery:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -5729,6 +5821,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         placeOfIssue:
           type: object
           title: Place of Issue
@@ -9066,6 +9162,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfLoad:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -9077,6 +9177,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfDischarge:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -9088,6 +9192,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPlaceOfDelivery:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -9099,6 +9207,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         shippedOnBoardDate:
           type: string
           format: date

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -609,6 +609,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfLoad:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -620,6 +624,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfDischarge:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -631,6 +639,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPlaceOfDelivery:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -642,6 +654,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         shippedOnBoardDate:
           type: string
           format: date

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1175,6 +1175,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfLoad:
           description: |
             The name to be used in order to specify how the `Port of Load` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -1186,6 +1190,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPortOfDischarge:
           description: |
             The name to be used in order to specify how the `Port of Discharge` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -1197,6 +1205,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         displayedNameForPlaceOfDelivery:
           description: |
             The name to be used in order to specify how the `Place of Delivery` should be displayed on the transport document to match the name and/or address provided on the letter of credit.
@@ -1208,6 +1220,10 @@ components:
             description: |
               A line of the address to be displayed on the transport document.
             example: 'Strawinskylaan 4117'
+          example:
+            - Strawinskylaan 457
+            - 1077 XX Amsterdam
+            - Nederlandene
         shippedOnBoardDate:
           type: string
           format: date


### PR DESCRIPTION
[DT-1223](https://dcsa.atlassian.net/browse/DT-1223) - Add example values for the `displayedNameForXXX` properties

[DT-1223]: https://dcsa.atlassian.net/browse/DT-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ