### PR TITLE
CS API- Pagination and description of various attribute changes

### DIFF
--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -26,7 +26,7 @@ info:
     Visit the [DCSA Website](https://dcsa.org/standards/commercial-schedules/) to find other documentation related to the standard publication (i.e. Interface Standard, Information Model).
 
     ### API Design & Implementation Principles
-    This API follows the guidelines defined in version 2.1 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design)
+    This API follows the guidelines defined in version 2.1 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design).
 
     For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/cs/v1#v100B1). Please also [create a GitHub issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any questions/comments.
 
@@ -61,6 +61,17 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned
+            Link:
+              schema:
+                type: string
+                example : <https://api.dcsa.org/v1/point-to-point?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/point-to-point?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
+              description: |
+                The `Link` header contains links to related pages. Each link has a relation type (`rel`) that indicates the relation of the linked page to the current page. The following are the allowed `Link` header relation types:
+
+                  - `first` - An optional link to the first page.
+                  - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
+                  - `next`  - A link to the next page. The next header linka MUST be omitted if the current page is the last page, otherwise it MUST be provided.
+                  - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
         '400':
           description: Bad Request
           headers:
@@ -267,6 +278,17 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
+            Link:
+              schema:
+                type: string
+                example : <https://api.dcsa.org/v1/port-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/port-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
+              description: |
+                The `Link` header contains links to related pages. Each link has a relation type (`rel`) that indicates the relation of the linked page to the current page. The following are the allowed `Link` header relation types:
+
+                  - `first` - An optional link to the first page.
+                  - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
+                  - `next`  - A link to the next page. The next header linka MUST be omitted if the current page is the last page, otherwise it MUST be provided.
+                  - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
         '400':
           description: Bad Request
           headers:
@@ -394,6 +416,17 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
+            Link:
+              schema:
+                type: string
+                example : <https://api.dcsa.org/v1/vessel-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/vessel-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
+              description: |
+                The `Link` header contains links to related pages. Each link has a relation type (`rel`) that indicates the relation of the linked page to the current page. The following are the allowed `Link` header relation types:
+
+                  - `first` - An optional link to the first page.
+                  - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
+                  - `next`  - A link to the next page. The next header linka MUST be omitted if the current page is the last page, otherwise it MUST be provided.
+                  - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
         '400':
           description: Bad Request
           headers:

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -28,7 +28,7 @@ info:
     ### API Design & Implementation Principles
     This API follows the guidelines defined in version 2.1 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design).
 
-    For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/cs/v1#v100B1). Please also [create a GitHub issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any questions/comments.
+    For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/cs/v1#v100). Please also [create a GitHub issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any questions/comments.
 
   license:
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -227,7 +227,7 @@ paths:
             minimum: 1
           in: query
           name: limit
-          description: Maximum number of items to return.
+          description: Specifies the maximum number of `Point-to-Point` objects to return.
         - schema:
             type: string
             maxLength: 1024
@@ -361,7 +361,7 @@ paths:
             minimum: 1
           in: query
           name: limit
-          description: Maximum number of items to return.
+          description: Specifies the maximum number of `Port Schedule` objects to return.
         - schema:
             type: string
             example: fE9mZnNldHw9MTAmbGltaXQ9MTA=
@@ -547,7 +547,7 @@ paths:
             minimum: 1
           in: query
           name: limit
-          description: Maximum number of items to return.
+          description: Specifies the maximum number of 'Service Schedule' objects to return.
         - schema:
             type: string
             example: fE9mZnNldHw9MTAmbGltaXQ9MTA=
@@ -561,7 +561,7 @@ paths:
 
         The list of schedules returned in the response can be tailored to specific needs by combining available query parameters. 
 
-        Examples of typical query parameters and expected payload returned in the response: 
+        A filter parameter or a combination of filter parameters MUST always be provided to call the endpoint. Examples of typical query parameters and expected payload returned in the response:
 
         - a) `carrierServiceCode`: Get all vessels and their full voyages within a service   
 
@@ -576,6 +576,8 @@ paths:
         - f) `UNLocationCode` **&** `facilitySMDGCode`: Get all vessels and their full voyages where the specific UNLocationCode and facilitySMDGCode is involved
 
         Other combinations using `vesselName`, `universalServiceReference`, `universalVoyageReference`, `vesselOperatorCarrierCode`, `startDate`, `endDate` are possible. 
+
+        The filter parameters `startDate` and `endDate` MUST always be used in combination with any of the other available parameters.
 
         The resulting payload returned in the responses will always include **entire voyage(s) being matched**. This means that even though a filter only matches a single `Port` (UNLocationCode) in a `Voyage` or a single `Timestamp` within a `Port` in a `Voyage` - **the entire Voyage matched** is returned. If the `carrierImportVoyageNumber` of the `Port` differs from the `carrierExportVoyageNumber` of the `Port` then the **entire Voyage** for both these Voyage numbers are included. An example of this is when `&UNLocationCode=DEHAM` is used as a filter parameter. In this case **entire Voyages** would be listed where `DEHAM` is a `Port`.
 

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -61,17 +61,13 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned
-            Link:
+            X-Next-Page-Cursor:
               schema:
                 type: string
-                example : <https://api.dcsa.org/v1/point-to-point-routes?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/point-to-point-routes?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
+                maxLength: 1024
+                example : fE9mZnNldHw9MTAmbGltaXQ9MTA=
               description: |
-                The `Link` header contains links to related pages. Each link has a relation type (`rel`) that indicates the relation of the linked page to the current page. The following are the allowed `Link` header relation types:
-
-                  - `first` - An optional link to the first page.
-                  - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
-                  - `next`  - A link to the next page. The next header link MUST be omitted if the current page is the last page, otherwise it MUST be provided.
-                  - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
+                The X-Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
         '400':
           description: Bad Request
           headers:
@@ -248,6 +244,7 @@ paths:
           in: query
           name: cursor
           description: 'A server generated value to specify a specific point in a collection result, used for pagination.'
+          example: fE9mZnNldHw9MTAmbGltaXQ9MTA=
         - $ref: '#/components/parameters/Api-Version-Major'
       description: |
         Provides the product offering of single or multiple estimated end-to-end route options for a shipment in the pre-booking phase. This includes point-to-point specification of all transport legs, estimated timings, estimated schedules and interdependencies between transport legs.
@@ -278,17 +275,13 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
-            Link:
+            X-Next-Page-Cursor:
               schema:
                 type: string
-                example : <https://api.dcsa.org/v1/port-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/port-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
+                maxLength: 1024
+                example : fE9mZnNldHw9MTAmbGltaXQ9MTA=
               description: |
-                The `Link` header contains links to related pages. Each link has a relation type (`rel`) that indicates the relation of the linked page to the current page. The following are the allowed `Link` header relation types:
-
-                  - `first` - An optional link to the first page.
-                  - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
-                  - `next`  - A link to the next page. The next header link MUST be omitted if the current page is the last page, otherwise it MUST be provided.
-                  - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
+                The X-Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
         '400':
           description: Bad Request
           headers:
@@ -416,17 +409,13 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
-            Link:
+            X-Next-Page-Cursor:
               schema:
                 type: string
-                example : <https://api.dcsa.org/v1/vessel-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/vessel-schedules?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
+                maxLength: 1024
+                example : fE9mZnNldHw9MTAmbGltaXQ9MTA=
               description: |
-                The `Link` header contains links to related pages. Each link has a relation type (`rel`) that indicates the relation of the linked page to the current page. The following are the allowed `Link` header relation types:
-
-                  - `first` - An optional link to the first page.
-                  - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
-                  - `next`  - A link to the next page. The next header link MUST be omitted if the current page is the last page, otherwise it MUST be provided.
-                  - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
+                The X-Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
         '400':
           description: Bad Request
           headers:

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -1045,7 +1045,7 @@ components:
         street:
           type: string
           example: Ruijggoordweg
-          maxLength: 100
+          maxLength: 70
         streetNumber:
           type: string
           example: '100'
@@ -1063,7 +1063,7 @@ components:
           type: string
           example: Amsterdam
           pattern: ^\S(?:.*\S)?$
-          maxLength: 65
+          maxLength: 35
         stateRegion:
           type: string
           example: North Holland

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -25,11 +25,6 @@ info:
 
     Visit the [DCSA Website](https://dcsa.org/standards/commercial-schedules/) to find other documentation related to the standard publication (i.e. Interface Standard, Information Model).
 
-
-    **Stats API**
-
-    The Stats API offers crucial statistical information for both API providers and consumers to enhance their services and helps DCSA to understand and scale the ecosystem. We expect you to invoke the Stats API for every request made to the Commercial Schedule API. Further details can be found [here](https://labs.dcsa.org/#/http/guides/api-guides/stats-api/introduction).
-
     For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/cs/v1#v100B1). Please also [create a GitHub issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any questions/comments.
 
   license:

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -61,13 +61,20 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned
-            X-Next-Page-Cursor:
+            Next-Page-Cursor:
               schema:
                 type: string
                 maxLength: 1024
                 example : fE9mZnNldHw9MTAmbGltaXQ9MTA=
               description: |
-                The X-Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
+                The Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
+                When an initial `GET` endpoint request includes the query parameter `limit=...` the API provider limits the number of items in the root array of the response to the specified limit. If the response would contain more items than the specified limit, the API provider includes only the first set of limit items and appends the following response header:
+                `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`, a string that acts as a reference for the next page of results. The cursor value is used in subsequent requests to retrieve the next page by passing it as a query parameter: `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
+                - To retrieve the next page, the API consumer sends a `GET` request to the endpoint with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as the query parameter.
+                - The same limit of items and any other query parameters applied in the initial request must remain unaltered in subsequent requests. If additional query parameters are passed along with the cursor, the API provider may return a `400 Bad Request` response.
+                - The behavior is consistent for subsequent pages, with the API provider appending the next page’s cursor in the `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` header, to be used in the following request as `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
+                - If a request exceeds the maximum allowed limit (if defined by the API implementer), the provider may return a `400 Bad Request` response.
+
         '400':
           description: Bad Request
           headers:
@@ -275,13 +282,19 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
-            X-Next-Page-Cursor:
+            Next-Page-Cursor:
               schema:
                 type: string
                 maxLength: 1024
                 example : fE9mZnNldHw9MTAmbGltaXQ9MTA=
               description: |
-                The X-Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
+                The Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
+                When an initial `GET` endpoint request includes the query parameter `limit=...` the API provider limits the number of items in the root array of the response to the specified limit. If the response would contain more items than the specified limit, the API provider includes only the first set of limit items and appends the following response header:
+                `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`, a string that acts as a reference for the next page of results. The cursor value is used in subsequent requests to retrieve the next page by passing it as a query parameter: `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
+                - To retrieve the next page, the API consumer sends a `GET` request to the endpoint with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as the query parameter.
+                - The same limit of items and any other query parameters applied in the initial request must remain unaltered in subsequent requests. If additional query parameters are passed along with the cursor, the API provider may return a `400 Bad Request` response.
+                - The behavior is consistent for subsequent pages, with the API provider appending the next page’s cursor in the `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` header, to be used in the following request as `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
+                - If a request exceeds the maximum allowed limit (if defined by the API implementer), the provider may return a `400 Bad Request` response.
         '400':
           description: Bad Request
           headers:
@@ -409,13 +422,19 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
-            X-Next-Page-Cursor:
+            Next-Page-Cursor:
               schema:
                 type: string
                 maxLength: 1024
                 example : fE9mZnNldHw9MTAmbGltaXQ9MTA=
               description: |
-                The X-Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
+                The Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
+                When an initial `GET` endpoint request includes the query parameter `limit=...` the API provider limits the number of items in the root array of the response to the specified limit. If the response would contain more items than the specified limit, the API provider includes only the first set of limit items and appends the following response header:
+                `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`, a string that acts as a reference for the next page of results. The cursor value is used in subsequent requests to retrieve the next page by passing it as a query parameter: `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
+                - To retrieve the next page, the API consumer sends a `GET` request to the endpoint with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as the query parameter.
+                - The same limit of items and any other query parameters applied in the initial request must remain unaltered in subsequent requests. If additional query parameters are passed along with the cursor, the API provider may return a `400 Bad Request` response.
+                - The behavior is consistent for subsequent pages, with the API provider appending the next page’s cursor in the `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` header, to be used in the following request as `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
+                - If a request exceeds the maximum allowed limit (if defined by the API implementer), the provider may return a `400 Bad Request` response.
         '400':
           description: Bad Request
           headers:

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -25,6 +25,9 @@ info:
 
     Visit the [DCSA Website](https://dcsa.org/standards/commercial-schedules/) to find other documentation related to the standard publication (i.e. Interface Standard, Information Model).
 
+    ### API Design & Implementation Principles
+    This API follows the guidelines defined in version 2.1 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design)
+
     For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/cs/v1#v100B1). Please also [create a GitHub issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any questions/comments.
 
   license:

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -547,7 +547,7 @@ paths:
             minimum: 1
           in: query
           name: limit
-          description: Specifies the maximum number of 'Service Schedule' objects to return.
+          description: Specifies the maximum number of `Service Schedule` objects to return.
         - schema:
             type: string
             example: fE9mZnNldHw9MTAmbGltaXQ9MTA=
@@ -767,7 +767,7 @@ components:
           example: CY
         cutOffTimes:
           type: array
-          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest deadline within which a task must be completed.
+          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest test date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
           items:
             $ref: '#/components/schemas/CutOffTime'
         solutionNumber:
@@ -778,7 +778,7 @@ components:
           description: 'Solution number, starting with 1. Used to group and identify similar or same routings in the response as per the carrier commercial definitions.'
         transitTime:
           type: integer
-          description: The estimated total time in **days** that it takes a shipment to move from place of receipt to place of delivery. Transit time includes stop-over time during transshipments and waiting time at connection points.
+          description: The estimated total time in days that it takes a shipment to move from place of receipt to place of delivery. Transit time includes stop-over time during transshipments and waiting time at connection points, if applicable, thus can vary between the same locations.
           format: int32
           example: 10
         legs:
@@ -844,7 +844,7 @@ components:
             $ref: '#/components/schemas/Timestamp'
         cutOffTimes:
           type: array
-          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest deadline within which a task must be completed.
+          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest test date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
           items:
             $ref: '#/components/schemas/CutOffTime'
     TransportCall:
@@ -892,6 +892,7 @@ components:
           minLength: 5
         cutOffTimes:
           type: array
+          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest test date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
           items:
             $ref: '#/components/schemas/CutOffTime'
         location:

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -64,13 +64,13 @@ paths:
             Link:
               schema:
                 type: string
-                example : <https://api.dcsa.org/v1/point-to-point?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/point-to-point?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
+                example : <https://api.dcsa.org/v1/point-to-point-routes?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="next",<https://api.dcsa.org/v1/point-to-point-routes?limit=20&cursor=f8dcb4c4-3fba-41ef-9991-2be97dad57dc>; rel="prev"
               description: |
                 The `Link` header contains links to related pages. Each link has a relation type (`rel`) that indicates the relation of the linked page to the current page. The following are the allowed `Link` header relation types:
 
                   - `first` - An optional link to the first page.
                   - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
-                  - `next`  - A link to the next page. The next header linka MUST be omitted if the current page is the last page, otherwise it MUST be provided.
+                  - `next`  - A link to the next page. The next header link MUST be omitted if the current page is the last page, otherwise it MUST be provided.
                   - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
         '400':
           description: Bad Request
@@ -287,7 +287,7 @@ paths:
 
                   - `first` - An optional link to the first page.
                   - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
-                  - `next`  - A link to the next page. The next header linka MUST be omitted if the current page is the last page, otherwise it MUST be provided.
+                  - `next`  - A link to the next page. The next header link MUST be omitted if the current page is the last page, otherwise it MUST be provided.
                   - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
         '400':
           description: Bad Request
@@ -425,7 +425,7 @@ paths:
 
                   - `first` - An optional link to the first page.
                   - `prev`  - An optional link to the previous page. The prev header link MUST be omitted if the current page is the first page.
-                  - `next`  - A link to the next page. The next header linka MUST be omitted if the current page is the last page, otherwise it MUST be provided.
+                  - `next`  - A link to the next page. The next header link MUST be omitted if the current page is the last page, otherwise it MUST be provided.
                   - `last`  - An optional link to the last page. The last header link MAY be omitted if the current page is the last page.
         '400':
           description: Bad Request
@@ -803,7 +803,7 @@ components:
           example: CY
         cutOffTimes:
           type: array
-          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest test date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
+          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
           items:
             $ref: '#/components/schemas/CutOffTime'
         solutionNumber:
@@ -880,7 +880,7 @@ components:
             $ref: '#/components/schemas/Timestamp'
         cutOffTimes:
           type: array
-          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest test date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
+          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
           items:
             $ref: '#/components/schemas/CutOffTime'
     TransportCall:
@@ -928,7 +928,7 @@ components:
           minLength: 5
         cutOffTimes:
           type: array
-          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest test date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
+          description: A list of cut-offs times provided by the carrier when available. A cut-off time indicates the latest date and time by which a task must be completed. For example, the latest date and time by which a container must be delivered to a terminal to be loaded on a vessel, or where certain documentation must be provided by the Shipper.
           items:
             $ref: '#/components/schemas/CutOffTime'
         location:

--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -70,10 +70,8 @@ paths:
                 The Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
                 When an initial `GET` endpoint request includes the query parameter `limit=...` the API provider limits the number of items in the root array of the response to the specified limit. If the response would contain more items than the specified limit, the API provider includes only the first set of limit items and appends the following response header:
                 `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`, a string that acts as a reference for the next page of results. The cursor value is used in subsequent requests to retrieve the next page by passing it as a query parameter: `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
-                - To retrieve the next page, the API consumer sends a `GET` request to the endpoint with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as the query parameter.
-                - The same limit of items and any other query parameters applied in the initial request must remain unaltered in subsequent requests. If additional query parameters are passed along with the cursor, the API provider may return a `400 Bad Request` response.
-                - The behavior is consistent for subsequent pages, with the API provider appending the next page’s cursor in the `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` header, to be used in the following request as `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
-                - If a request exceeds the maximum allowed limit (if defined by the API implementer), the provider may return a `400 Bad Request` response.
+
+                To retrieve the next page, the API consumer sends a `GET` request to the endpoint URL with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as query parameter. The limit of items per page and any other query parameters may not be altered, therefore it may also not be specified when requesting subsequent pages. The API provider must ignore any query parameters passed along with a cursor, and should return a `400` error if any other query parameter is passed along with the `cursor`.
 
         '400':
           description: Bad Request
@@ -291,10 +289,8 @@ paths:
                 The Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
                 When an initial `GET` endpoint request includes the query parameter `limit=...` the API provider limits the number of items in the root array of the response to the specified limit. If the response would contain more items than the specified limit, the API provider includes only the first set of limit items and appends the following response header:
                 `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`, a string that acts as a reference for the next page of results. The cursor value is used in subsequent requests to retrieve the next page by passing it as a query parameter: `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
-                - To retrieve the next page, the API consumer sends a `GET` request to the endpoint with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as the query parameter.
-                - The same limit of items and any other query parameters applied in the initial request must remain unaltered in subsequent requests. If additional query parameters are passed along with the cursor, the API provider may return a `400 Bad Request` response.
-                - The behavior is consistent for subsequent pages, with the API provider appending the next page’s cursor in the `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` header, to be used in the following request as `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
-                - If a request exceeds the maximum allowed limit (if defined by the API implementer), the provider may return a `400 Bad Request` response.
+
+                To retrieve the next page, the API consumer sends a `GET` request to the endpoint URL with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as query parameter. The limit of items per page and any other query parameters may not be altered, therefore it may also not be specified when requesting subsequent pages. The API provider must ignore any query parameters passed along with a cursor, and should return a `400` error if any other query parameter is passed along with the `cursor`.
         '400':
           description: Bad Request
           headers:
@@ -431,10 +427,8 @@ paths:
                 The Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
                 When an initial `GET` endpoint request includes the query parameter `limit=...` the API provider limits the number of items in the root array of the response to the specified limit. If the response would contain more items than the specified limit, the API provider includes only the first set of limit items and appends the following response header:
                 `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`, a string that acts as a reference for the next page of results. The cursor value is used in subsequent requests to retrieve the next page by passing it as a query parameter: `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
-                - To retrieve the next page, the API consumer sends a `GET` request to the endpoint with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as the query parameter.
-                - The same limit of items and any other query parameters applied in the initial request must remain unaltered in subsequent requests. If additional query parameters are passed along with the cursor, the API provider may return a `400 Bad Request` response.
-                - The behavior is consistent for subsequent pages, with the API provider appending the next page’s cursor in the `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` header, to be used in the following request as `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=`.
-                - If a request exceeds the maximum allowed limit (if defined by the API implementer), the provider may return a `400 Bad Request` response.
+
+                To retrieve the next page, the API consumer sends a `GET` request to the endpoint URL with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA=` as query parameter. The limit of items per page and any other query parameters may not be altered, therefore it may also not be specified when requesting subsequent pages. The API provider must ignore any query parameters passed along with a cursor, and should return a `400` error if any other query parameter is passed along with the `cursor`.
         '400':
           description: Bad Request
           headers:


### PR DESCRIPTION
This PR includes the below jira issues : 

- [APCV-1217](https://dcsa.atlassian.net/browse/APCV-1217) - Added pagination link headers to all the endpoints
- [APCV-1218](https://dcsa.atlassian.net/browse/APCV-1218) - Removed Stats API link and text 
- [APCV- 1219](https://dcsa.atlassian.net/browse/APCV-1219) - Updated the limit parameter description and the description regarding filters in vesselSchedules endpoint.
- [APCV-1228](https://dcsa.atlassian.net/browse/APCV-1228) - Updated the description of transitTime and cutOffTimes
- [APCV-1230](https://dcsa.atlassian.net/browse/APCV-1230) - Updated the API design principles link in API spec

[APCV-1217]: https://dcsa.atlassian.net/browse/APCV-1217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APCV-1218]: https://dcsa.atlassian.net/browse/APCV-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APCV-1228]: https://dcsa.atlassian.net/browse/APCV-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APCV-1230]: https://dcsa.atlassian.net/browse/APCV-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ