### PR TITLE
DT-1590,DT-1512: Modify partyName maxLength on Receiver

### DIFF
--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -525,7 +525,7 @@ components:
         partyName:
           type: string
           pattern: ^\S(?:.*\S)?$
-          maxLength: 100
+          maxLength: 70
           description: |
             Name of the party.
           example: Globeteam


### PR DESCRIPTION
[DT-1590](https://dcsa.atlassian.net/browse/DT-1590) - Receiver in the PINT API was forgotten in the original PR - fixed here

[DT-1590]: https://dcsa.atlassian.net/browse/DT-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ