### PR TITLE
Dt-1529,DT-1531,DT-1532: Remove GitHub links and remove links to specific versions

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -7545,7 +7545,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the `packageCode` as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer

--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -2795,8 +2795,6 @@ components:
                 - `DECLINED` (Booking discontinued by carrier after it has been Confirmed)
                 - `CANCELLED` (Booking discontinued by consumer)
                 - `COMPLETED` (The Transport Document this Booking is connected to has been Surrendered for Delivery)
-
-                More details can be found on [GitHub](https://github.com/dcsaorg/DCSA-Edocumentation/blob/master/edocumentation-domain/src/main/resources/validations/bookingstatuses.csv).
               example: RECEIVED
             amendedBookingStatus:
               type: string
@@ -2808,8 +2806,6 @@ components:
                 - `AMENDMENT_CONFIRMED` (Amendment is confirmed)
                 - `AMENDMENT_DECLINED` (Amendment discontinued by provider)
                 - `AMENDMENT_CANCELLED` (Amendment discontinued by consumer)
-
-                More details can be found on [GitHub](https://github.com/dcsaorg/DCSA-Edocumentation/blob/master/edocumentation-domain/src/main/resources/validations/bookingstatuses.csv).
               example: AMENDMENT_RECEIVED
             bookingCancellationStatus:
               type: string
@@ -3139,7 +3135,7 @@ components:
                   minLength: 3
                   maxLength: 3
                   description: |
-                    The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217).
+                    The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
                   example: DKK
                 carrierCode:
                   type: string
@@ -3241,18 +3237,7 @@ components:
                   type: string
                   maxLength: 3
                   description: |
-                    Transport obligations, costs and risks as agreed between buyer and seller as defined by [ICC](https://iccwbo.org/business-solutions/incoterms-rules/). A list of possible values:
-                    - `EXW` (Ex-Works)
-                    - `FCA` (Free Carrier)
-                    - `FAS` (Free Alongside Ship)
-                    - `FOB` (Free On Board)
-                    - `CFR` (Cost and Freight)
-                    - `CIF` (Cost, Insurance and Freight)
-                    - `CPT` (Carriage Paid To)
-                    - `CIP` (Carriage And Insurance Paid To)
-                    - `DAP` (Delivered At Place)
-                    - `DPU` (Delivered At Place Unloaded)
-                    - `DDP` (Delivered Duty Paid)
+                    Transport obligations, costs and risks as agreed between buyer and seller as defined by [Incoterms Rules](https://iccwbo.org/business-solutions/incoterms-rules/).
                   example: FCA
                 communicationChannelCode:
                   type: string
@@ -3864,18 +3849,7 @@ components:
                   type: string
                   maxLength: 3
                   description: |
-                    Transport obligations, costs and risks as agreed between buyer and seller as defined by [ICC](https://iccwbo.org/business-solutions/incoterms-rules/). A list of possible values:
-                    - `EXW` (Ex-Works)
-                    - `FCA` (Free Carrier)
-                    - `FAS` (Free Alongside Ship)
-                    - `FOB` (Free On Board)
-                    - `CFR` (Cost and Freight)
-                    - `CIF` (Cost, Insurance and Freight)
-                    - `CPT` (Carriage Paid To)
-                    - `CIP` (Carriage And Insurance Paid To)
-                    - `DAP` (Delivered At Place)
-                    - `DPU` (Delivered At Place Unloaded)
-                    - `DDP` (Delivered Duty Paid)
+                    Transport obligations, costs and risks as agreed between buyer and seller as defined by [Incoterms Rules](https://iccwbo.org/business-solutions/incoterms-rules/).
                   example: FCA
                 communicationChannelCode:
                   type: string
@@ -4760,18 +4734,7 @@ components:
           type: string
           maxLength: 3
           description: |
-            Transport obligations, costs and risks as agreed between buyer and seller as defined by [ICC](https://iccwbo.org/business-solutions/incoterms-rules/). A list of possible values:
-            - `EXW` (Ex-Works)
-            - `FCA` (Free Carrier)
-            - `FAS` (Free Alongside Ship)
-            - `FOB` (Free On Board)
-            - `CFR` (Cost and Freight)
-            - `CIF` (Cost, Insurance and Freight)
-            - `CPT` (Carriage Paid To)
-            - `CIP` (Carriage And Insurance Paid To)
-            - `DAP` (Delivered At Place)
-            - `DPU` (Delivered At Place Unloaded)
-            - `DDP` (Delivered Duty Paid)
+            Transport obligations, costs and risks as agreed between buyer and seller as defined by [Incoterms Rules](https://iccwbo.org/business-solutions/incoterms-rules/).
           example: FCA
         communicationChannelCode:
           type: string
@@ -5273,18 +5236,7 @@ components:
           type: string
           maxLength: 3
           description: |
-            Transport obligations, costs and risks as agreed between buyer and seller as defined by [ICC](https://iccwbo.org/business-solutions/incoterms-rules/). A list of possible values:
-            - `EXW` (Ex-Works)
-            - `FCA` (Free Carrier)
-            - `FAS` (Free Alongside Ship)
-            - `FOB` (Free On Board)
-            - `CFR` (Cost and Freight)
-            - `CIF` (Cost, Insurance and Freight)
-            - `CPT` (Carriage Paid To)
-            - `CIP` (Carriage And Insurance Paid To)
-            - `DAP` (Delivered At Place)
-            - `DPU` (Delivered At Place Unloaded)
-            - `DDP` (Delivered Duty Paid)
+            Transport obligations, costs and risks as agreed between buyer and seller as defined by [Incoterms Rules](https://iccwbo.org/business-solutions/incoterms-rules/).
           example: FCA
         communicationChannelCode:
           type: string
@@ -5832,18 +5784,7 @@ components:
           type: string
           maxLength: 3
           description: |
-            Transport obligations, costs and risks as agreed between buyer and seller as defined by [ICC](https://iccwbo.org/business-solutions/incoterms-rules/). A list of possible values:
-            - `EXW` (Ex-Works)
-            - `FCA` (Free Carrier)
-            - `FAS` (Free Alongside Ship)
-            - `FOB` (Free On Board)
-            - `CFR` (Cost and Freight)
-            - `CIF` (Cost, Insurance and Freight)
-            - `CPT` (Carriage Paid To)
-            - `CIP` (Carriage And Insurance Paid To)
-            - `DAP` (Delivered At Place)
-            - `DPU` (Delivered At Place Unloaded)
-            - `DDP` (Delivered Duty Paid)
+            Transport obligations, costs and risks as agreed between buyer and seller as defined by [Incoterms Rules](https://iccwbo.org/business-solutions/incoterms-rules/).
           example: FCA
         communicationChannelCode:
           type: string
@@ -6713,7 +6654,7 @@ components:
       description: |
         Reference that uniquely identifies a party for tax and/or legal purposes in accordance with the relevant jurisdiction.
 
-        A list of examples:
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -6724,8 +6665,6 @@ components:
         |RUC|PE|Registro Único del Contribuyente in Peru|
         |NIF|MG|Numéro d'Identification Fiscal in Madagascar|
         |NIF|DZ|Numéro d'Identification Fiscal in Algeria|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/taxandlegalreferences-v300.csv).
       properties:
         type:
           type: string
@@ -6741,7 +6680,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: DK
+          example: IN
         value:
           type: string
           pattern: ^\S(?:.*\S)?$
@@ -6819,7 +6758,7 @@ components:
       description: |
         Reference associated with customs and/or excise purposes required by the relevant authorities for the import, export, or transit of the goods.
 
-        A (small) list of examples:
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -6828,8 +6767,6 @@ components:
         |ITN|US|Internal Transaction Number in US|
         |PEB|ID|PEB reference number|
         |CSN|IN|Cargo Summary Notification (CSN)|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/customsreferences-v300.csv).
       properties:
         type:
           type: string
@@ -6845,7 +6782,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: NL
+          example: EG
         values:
           type: array
           minItems: 1
@@ -6951,7 +6888,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://en.wikipedia.org/wiki/ISO_6346) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
           example: 22RT
         units:
           type: integer
@@ -7068,7 +7005,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://en.wikipedia.org/wiki/ISO_6346) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
           example: 22RT
         units:
           type: integer
@@ -7328,9 +7265,7 @@ components:
             description: |
               Used by customs to classify the product being shipped. The type of HS code depends on country and customs requirements. The code must be at least 6 and at most 10 digits.
 
-              More information can be found here: [HS Nomenclature 2022 edition](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools/hs-nomenclature-2022-edition/hs-nomenclature-2022-edition.aspx).
-
-              This standard is based on the 2022 revision.
+              More information can be found here: [HS Nomenclature](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools).
             example: '851713'
         nationalCommodityCodes:
           type: array
@@ -7443,9 +7378,7 @@ components:
             description: |
               Used by customs to classify the product being shipped. The type of HS code depends on country and customs requirements. The code must be at least 6 and at most 10 digits.
 
-              More information can be found here: [HS Nomenclature 2022 edition](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools/hs-nomenclature-2022-edition/hs-nomenclature-2022-edition.aspx).
-
-              This standard is based on the 2022 revision.
+              More information can be found here: [HS Nomenclature](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools).
             example: '851713'
         nationalCommodityCodes:
           type: array
@@ -7600,7 +7533,7 @@ components:
           minLength: 2
           maxLength: 2
           description: |
-            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21 - Revision 12 Annexes V and VI](https://unece.org/sites/default/files/2021-06/rec21_Rev12e_Annex-V-VI_2021.xls)
+            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21](https://unece.org/trade/uncefact/cl-recommendations)
 
             **Condition:** only applicable to dangerous goods if the `IMO packaging code` is not available.
           example: 5H
@@ -7612,7 +7545,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the IMO IMDG code amendment version 41-22. If not available, the `packageCode` as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer
@@ -7707,8 +7640,6 @@ components:
             - `1.6N` (Extremely insensitive articles which do not have a mass explosion hazard)
             - `2.1` (Flammable gases)
             - `8` (Corrosive substances)
-
-            The value must comply with one of the values in the [DG IMO Class value table](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/dcsa/reference-data/imoclasses-v3.1.0.csv)
           example: 1.4S
         subsidiaryRisk1:
           type: string
@@ -8081,7 +8012,7 @@ components:
           description: |
             Lowest temperature at which a chemical can vaporize to form an ignitable mixture in air.
             
-            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code amendment version 41-22.
+            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code.
           example: 42
         transportControlTemperature:
           type: number
@@ -8124,7 +8055,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://en.wikipedia.org/wiki/ISO_6346) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
           example: 22GP
         units:
           type: integer
@@ -8406,7 +8337,7 @@ components:
       description: |
         An Advance Manifest Filing defined by a Manifest type code in combination with a country code.
 
-        A list of `manifestTypeCodes` together with `countryCode` is maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/advancemanifestfilings-v300.csv). A (small) subset can be seen here:
+        A small list of potential examples:
 
         | manifestTypeCode | countryCode | Description |
         |-----------------------|:-------------:|-------------|
@@ -8419,7 +8350,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 50
           description: |
-            The Manifest type code as defined by the provider. A list of `manifestTypeCodes` together with `countryCode` is maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/advancemanifestfilings-v300.csv)
+            The Manifest type code as defined by the provider.
           example: ACE
         countryCode:
           type: string
@@ -8428,7 +8359,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: DK
+          example: US
       example:
         manifestTypeCode: ACE
         countryCode: US
@@ -8465,7 +8396,7 @@ components:
           minLength: 3
           maxLength: 3
           description: |
-            The currency for the charge, using a 3-character code ([ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)).
+            The currency for the charge, using a 3-character code ([ISO 4217](https://www.iso.org/iso-4217-currency-codes.html)).
           example: DKK
         paymentTermCode:
           type: string

--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -6888,7 +6888,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22RT
         units:
           type: integer
@@ -7005,7 +7005,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22RT
         units:
           type: integer
@@ -8055,8 +8055,8 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
-          example: 22GP
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+          example: 22G1
         units:
           type: integer
           format: int32
@@ -8337,7 +8337,7 @@ components:
       description: |
         An Advance Manifest Filing defined by a Manifest type code in combination with a country code.
 
-        A small list of potential examples:
+        A small list of **potential** examples:
 
         | manifestTypeCode | countryCode | Description |
         |-----------------------|:-------------:|-------------|

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -3020,8 +3020,6 @@ components:
                 - `RECEIVED` (Shipping Instructions has been received)
                 - `PENDING_UPDATE` (An update is required to the Shipping Instructions)
                 - `COMPLETED` (The Shipping Instructions can no longer be modified - the related Transport Document has been surrendered for delivery)
-
-                More details can be found on [GitHub](https://github.com/dcsaorg/DCSA-Edocumentation/blob/master/edocumentation-domain/src/main/resources/validations/eblstatuses.csv).
               example: RECEIVED
             updatedShippingInstructionsStatus:
               type: string
@@ -3033,8 +3031,6 @@ components:
                 - `UPDATE_CONFIRMED` (Update is confirmed)
                 - `UPDATE_CANCELLED` (An update to a Shipping Instructions is discontinued by consumer)
                 - `UPDATE_DECLINED` (An update to a Shipping Instructions is discontinued by provider)
-
-                More details can be found on [GitHub](https://github.com/dcsaorg/DCSA-Edocumentation/blob/master/edocumentation-domain/src/main/resources/validations/eblstatuses.csv).
               example: UPDATE_RECEIVED
             shippingInstructionsReference:
               type: string
@@ -3247,8 +3243,6 @@ components:
                     - `BRIT` (BRITC eBL)
 
                     **Condition:** Mandatory for electronic Bill of Lading (`isElectronic=true`).
-                    
-                    Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0-Beta-2.csv).
                   example: WAVE
                 isToOrder:
                   type: boolean
@@ -3719,8 +3713,6 @@ components:
                     - `BRIT` (BRITC eBL)
 
                     **Condition:** Mandatory for electronic Bill of Lading (`isElectronic=true`).
-                    
-                    Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0-Beta-2.csv).
                   example: WAVE
                 isToOrder:
                   type: boolean
@@ -4103,8 +4095,6 @@ components:
                 - `VOID` (the Transport Document has been Voided)
                 - `PENDING_SURRENDER_FOR_DELIVERY` (Transport Document pending surrender for Delivery)
                 - `SURRENDER_FOR_DELIVERY` (Transport Document surrendered for Delivery)
-
-                More details can be found on [GitHub](https://github.com/dcsaorg/DCSA-Edocumentation/blob/master/edocumentation-domain/src/main/resources/validations/eblstatuses.csv).
               example: DRAFT
             shippingInstructionsReference:
               type: string
@@ -4392,7 +4382,7 @@ components:
                   minLength: 3
                   maxLength: 3
                   description: |
-                    The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217).
+                    The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
                   example: DKK
                 carrierCode:
                   type: string
@@ -4784,8 +4774,6 @@ components:
             - `BRIT` (BRITC eBL)
 
             **Condition:** Mandatory for electronic Bill of Lading (`isElectronic=true`).
-            
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0-Beta-2.csv).
           example: WAVE
         isToOrder:
           type: boolean
@@ -5216,8 +5204,6 @@ components:
             - `BRIT` (BRITC eBL)
 
             **Condition:** Mandatory for electronic Bill of Lading (`isElectronic=true`).
-            
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0-Beta-2.csv).
           example: WAVE
         isToOrder:
           type: boolean
@@ -5675,8 +5661,6 @@ components:
             - `BRIT` (BRITC eBL)
 
             **Condition:** Mandatory for electronic Bill of Lading (`isElectronic=true`).
-            
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0-Beta-2.csv).
           example: WAVE
         isToOrder:
           type: boolean
@@ -6869,8 +6853,6 @@ components:
             - `ETEU` (eTEU)
             - `TRAC` (TRACE Original)
             - `BRIT` (BRITC eBL)
-            
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0.csv).
           example: BOLE
         identifyingCodes:
           type: array
@@ -7251,9 +7233,18 @@ components:
       title: Tax & Legal Reference
       description: |
         Reference that uniquely identifies a party for tax and/or legal purposes in accordance with the relevant jurisdiction.
-        A list of examples:
-        | Type  | Country | Description | |-------|:-------:|-------------| |PAN|IN|Goods and Services Tax Identification Number in India| |GSTIN|IN|Goods and Services Tax Identification Number in India| |IEC|IN|Importer-Exported Code in India| |RUC|EC|Registro Único del Contribuyente in Ecuador| |RUC|PE|Registro Único del Contribuyente in Peru| |NIF|MG|Numéro d’Identification Fiscal in Madagascar| |NIF|DZ|Numéro d’Identification Fiscal in Algeria|
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/taxandlegalreferences-v300.csv).
+
+        A small list of **potential** examples:
+
+        | Type  | Country | Description |
+        |-------|:-------:|-------------|
+        |PAN|IN|Goods and Services Tax Identification Number in India|
+        |GSTIN|IN|Goods and Services Tax Identification Number in India|
+        |IEC|IN|Importer-Exported Code in India|
+        |RUC|EC|Registro Único del Contribuyente in Ecuador|
+        |RUC|PE|Registro Único del Contribuyente in Peru|
+        |NIF|MG|Numéro d'Identification Fiscal in Madagascar|
+        |NIF|DZ|Numéro d'Identification Fiscal in Algeria|
       properties:
         type:
           type: string
@@ -7269,7 +7260,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: NL
+          example: IN
         value:
           type: string
           pattern: ^\S(?:.*\S)?$
@@ -7362,9 +7353,7 @@ components:
             description: |
               Used by customs to classify the product being shipped. The type of HS code depends on country and customs requirements. The code must be at least 6 and at most 10 digits.
 
-              More information can be found here: [HS Nomenclature 2022 edition](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools/hs-nomenclature-2022-edition/hs-nomenclature-2022-edition.aspx ).
-
-              This standard is based on the 2022 revision.
+              More information can be found here: [HS Nomenclature](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools).
             example: '851713'
         nationalCommodityCodes:
           type: array
@@ -7463,9 +7452,7 @@ components:
             description: |
               Used by customs to classify the product being shipped. The type of HS code depends on country and customs requirements. The code must be at least 6 and at most 10 digits.
 
-              More information can be found here: [HS Nomenclature 2022 edition](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools/hs-nomenclature-2022-edition/hs-nomenclature-2022-edition.aspx ).
-
-              This standard is based on the 2022 revision.
+              More information can be found here: [HS Nomenclature](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools).
             example: '851713'
         nationalCommodityCodes:
           type: array
@@ -7576,7 +7563,7 @@ components:
       description: |
         Reference associated with customs and/or excise purposes required by the relevant authorities for the import, export, or transit of the goods.
 
-        A (small) list of examples:
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -7585,8 +7572,6 @@ components:
         |ITN|US|Internal Transaction Number in US|
         |PEB|ID|PEB reference number|
         |CSN|IN|Cargo Summary Notification (CSN)|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/customsreferences-v300.csv).
       properties:
         type:
           type: string
@@ -7602,7 +7587,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: NL
+          example: EG
         values:
           type: array
           minItems: 1
@@ -7824,7 +7809,7 @@ components:
           minLength: 2
           maxLength: 2
           description: |
-            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21 - Revision 12  Annexes V and VI](https://unece.org/sites/default/files/2021-06/rec21_Rev12e_Annex-V-VI_2021.xls)
+            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21](https://unece.org/trade/uncefact/cl-recommendations)
 
             **Condition:** only applicable to dangerous goods if the `IMO packaging code` is not available.
           example: 5H
@@ -7867,7 +7852,7 @@ components:
           minLength: 2
           maxLength: 2
           description: |
-            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21 - Revision 12  Annexes V and VI](https://unece.org/sites/default/files/2021-06/rec21_Rev12e_Annex-V-VI_2021.xls)
+            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21](https://unece.org/trade/uncefact/cl-recommendations)
 
             **Condition:** only applicable to dangerous goods if the `IMO packaging code` is not available.
           example: 5H
@@ -7879,7 +7864,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the IMO IMDG code amendment version 41-22. If not available, the package code as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer
@@ -7987,8 +7972,6 @@ components:
             - `1.6N` (Extremely insensitive articles which do not have a mass explosion hazard)
             - `2.1` (Flammable gases)
             - `8` (Corrosive substances)
-
-            The value must comply with one of the values in the [DG IMO Class value table](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/dcsa/reference-data/imoclasses-v3.1.0.csv)
           example: 1.4S
         subsidiaryRisk1:
           type: string
@@ -8345,7 +8328,7 @@ components:
           description: |
             Lowest temperature at which a chemical can vaporize to form an ignitable mixture in air.
             
-            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code amendment version 41-22.
+            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code.
           example: 42
         transportControlTemperature:
           type: number
@@ -8545,7 +8528,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://en.wikipedia.org/wiki/ISO_6346) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
           example: 22GP
         tareWeight:
           type: number
@@ -8590,7 +8573,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://en.wikipedia.org/wiki/ISO_6346) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
           example: 22GP
         tareWeight:
           type: number
@@ -8760,7 +8743,7 @@ components:
       description: |
         An Advance Manifest Filing defined by a Manifest type code in combination with a country code.
 
-        A list of `manifestTypeCodes` together with `countryCode` is maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/advancemanifestfilings-v300.csv). A (small) subset can be seen here:
+        A small list of potential examples:
 
         | manifestTypeCode | countryCode | Description |
         |-----------------------|:-------------:|-------------|
@@ -8774,7 +8757,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 50
           description: |
-            The Manifest type code as defined by the provider. A list of `manifestTypeCodes` together with `countryCode` is maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/advancemanifestfilings-v300.csv)
+            The Manifest type code as defined by the provider.
           example: ENS
         countryCode:
           type: string
@@ -9006,8 +8989,6 @@ components:
         - `VESSEL_PARTICULARS_16` (Vessel Particulars 16)
         - `VESSEL_PARTICULARS_17` (Vessel Particulars 17)
         - `VESSEL_PARTICULARS_18` (Vessel Particulars 18)
-
-        More details can be found on [GitHub](https://github.com/dcsaorg/DCSA-Edocumentation/blob/master/edocumentation-domain/src/main/resources/validations/carriercertificates.csv).
       example: VESSEL_PARTICULARS_1
 
     ###########################
@@ -9025,8 +9006,6 @@ components:
         - `CARGO_CARGOVALUE` (Cargo/Cargo value)
         - `CARGO_REEFERTEMPERATURE` (Cargo/Reefer temperature)
         - `CARGO_CONFLICTINGTEMPERATURES_MIXEDLOADS` (Cargo/Conflicting temperatures / Mixed loads)
-
-        More information can be read [here](https://dcsa.org/wp-content/uploads/2023/12/202312-Standardised-Clauses-BL.pdf)
       example: CARGO_CARGOSPECIFICS
 
     ####################
@@ -9294,7 +9273,7 @@ components:
           minLength: 3
           maxLength: 3
           description: |
-            The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217).
+            The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
           example: DKK
         carrierCode:
           type: string
@@ -9869,7 +9848,7 @@ components:
           minLength: 3
           maxLength: 3
           description: |
-            The currency for the charge, using a 3-character code ([ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)).
+            The currency for the charge, using a 3-character code ([ISO 4217](https://www.iso.org/iso-4217-currency-codes.html)).
           example: DKK
         paymentTermCode:
           type: string

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -7864,7 +7864,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the `packageCode` as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -995,7 +995,7 @@ paths:
                         seals:
                           - number: DCSA-CTK-1234
                         equipment:
-                          ISOEquipmentCode: 22GP
+                          ISOEquipmentCode: 22G1
                           equipmentReference: HLXU1234567
                           tareWeight: 2370
                           weightUnit: KGM
@@ -1799,7 +1799,7 @@ paths:
                         cargoGrossWeight: 12000
                         cargoGrossWeightUnit: KGM
                         equipment:
-                          ISOEquipmentCode: 22GP
+                          ISOEquipmentCode: 22G1
                           equipmentReference: HLXU1234567
         '202':
           description: |
@@ -8528,8 +8528,8 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
-          example: 22GP
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+          example: 22G1
         tareWeight:
           type: number
           format: float
@@ -8573,8 +8573,8 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
-          example: 22GP
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+          example: 22G1
         tareWeight:
           type: number
           format: float
@@ -8743,7 +8743,7 @@ components:
       description: |
         An Advance Manifest Filing defined by a Manifest type code in combination with a country code.
 
-        A small list of potential examples:
+        A small list of **potential** examples:
 
         | manifestTypeCode | countryCode | Description |
         |-----------------------|:-------------:|-------------|

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -1960,8 +1960,8 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
-          example: 22GP
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+          example: 22G1
         tareWeight:
           type: number
           format: float

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -374,8 +374,6 @@ components:
             - `ETEU` (eTEU)
             - `TRAC` (TRACE Original)
             - `BRIT` (BRITC eBL)
-            
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0.csv).
           example: BOLE
         identifyingCodes:
           type: array
@@ -450,7 +448,8 @@ components:
       title: Tax & Legal Reference
       description: |
         Reference that uniquely identifies a party for tax and/or legal purposes in accordance with the relevant jurisdiction.
-        A list of examples:
+
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -461,8 +460,6 @@ components:
         |RUC|PE|Registro Único del Contribuyente in Peru|
         |NIF|MG|Numéro d'Identification Fiscal in Madagascar|
         |NIF|DZ|Numéro d'Identification Fiscal in Algeria|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/taxandlegalreferences-v300.csv).
       properties:
         type:
           type: string
@@ -478,7 +475,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: DK
+          example: IN
         value:
           type: string
           pattern: ^\S(?:.*\S)?$
@@ -756,7 +753,7 @@ components:
           minLength: 3
           maxLength: 3
           description: |
-            The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217).
+            The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
           example: DKK
         carrierCode:
           type: string
@@ -1116,9 +1113,7 @@ components:
             description: |
               Used by customs to classify the product being shipped. The type of HS code depends on country and customs requirements. The code must be at least 6 and at most 10 digits.
 
-              More information can be found here: [HS Nomenclature 2022 edition](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools/hs-nomenclature-2022-edition/hs-nomenclature-2022-edition.aspx ).
-
-              This standard is based on the 2022 revision.
+              More information can be found here: [HS Nomenclature](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools).
             example: '851713'
         nationalCommodityCodes:
           type: array
@@ -1229,7 +1224,7 @@ components:
       description: |
         Reference associated with customs and/or excise purposes required by the relevant authorities for the import, export, or transit of the goods.
 
-        A (small) list of examples:
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -1238,8 +1233,6 @@ components:
         |ITN|US|Internal Transaction Number in US|
         |PEB|ID|PEB reference number|
         |CSN|IN|Cargo Summary Notification (CSN)|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/customsreferences-v300.csv).
       properties:
         type:
           type: string
@@ -1255,7 +1248,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: DK
+          example: EG
         values:
           type: array
           minItems: 1
@@ -1378,7 +1371,7 @@ components:
           minLength: 2
           maxLength: 2
           description: |
-            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21 - Revision 12  Annexes V and VI](https://unece.org/sites/default/files/2021-06/rec21_Rev12e_Annex-V-VI_2021.xls)
+            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21](https://unece.org/trade/uncefact/cl-recommendations)
 
             **Condition:** only applicable to dangerous goods if the `IMO packaging code` is not available.
           example: 5H
@@ -1390,7 +1383,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the IMO IMDG code amendment version 41-22. If not available, the package code as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer
@@ -1498,8 +1491,6 @@ components:
             - `1.6N` (Extremely insensitive articles which do not have a mass explosion hazard)
             - `2.1` (Flammable gases)
             - `8` (Corrosive substances)
-
-            The value must comply with one of the values in the [DG IMO Class value table](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/dcsa/reference-data/imoclasses-v3.1.0.csv)
           example: 1.4S
         subsidiaryRisk1:
           type: string
@@ -1856,7 +1847,7 @@ components:
           description: |
             Lowest temperature at which a chemical can vaporize to form an ignitable mixture in air.
             
-            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code amendment version 41-22.
+            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code.
           example: 42
         transportControlTemperature:
           type: number
@@ -1969,7 +1960,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://en.wikipedia.org/wiki/ISO_6346) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
           example: 22GP
         tareWeight:
           type: number
@@ -2438,7 +2429,7 @@ components:
           minLength: 3
           maxLength: 3
           description: |
-            The currency for the charge, using a 3-character code ([ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)).
+            The currency for the charge, using a 3-character code ([ISO 4217](https://www.iso.org/iso-4217-currency-codes.html)).
           example: DKK
         paymentTermCode:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -1383,7 +1383,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the `packageCode` as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer

--- a/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
+++ b/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
@@ -166,8 +166,6 @@ components:
             - `ETEU` (eTEU)
             - `TRAC` (TRACE Original)
             - `BRIT` (BRITC eBL)
-
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0.csv).
           example: BOLE
         partyName:
           type: string
@@ -343,7 +341,8 @@ components:
       title: Tax & Legal Reference
       description: |
         Reference that uniquely identifies a party for tax and/or legal purposes in accordance with the relevant jurisdiction.
-        A list of examples:
+
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -352,10 +351,8 @@ components:
         |IEC|IN|Importer-Exported Code in India|
         |RUC|EC|Registro Único del Contribuyente in Ecuador|
         |RUC|PE|Registro Único del Contribuyente in Peru|
-        |NIF|MG|Numéro d’Identification Fiscal in Madagascar|
-        |NIF|DZ|Numéro d’Identification Fiscal in Algeria|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/taxandlegalreferences-v300.csv).
+        |NIF|MG|Numéro d'Identification Fiscal in Madagascar|
+        |NIF|DZ|Numéro d'Identification Fiscal in Algeria|
       properties:
         type:
           type: string
@@ -371,7 +368,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: DK
+          example: IN
         value:
           type: string
           pattern: ^\S(?:.*\S)?$

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1947,7 +1947,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the `packageCode` as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -2524,7 +2524,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22GP
         tareWeight:
           type: number

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -33,7 +33,7 @@ info:
     - **'Digital copy of the original physical B/L document' document** (described via [`EnvelopeManifest.eBLVisualisationByCarrier`](#/EnvelopeManifest) schema object that has been previously transferred via [**'Start envelope transfer'**](#/Start%20envelope%20transfer) endpoint as JWS-signed payload of [`EblEnvelope.envelopeManifestSignedContent`](#/EblEnvelope) schema object) a.k.a. **eBLVisualisationByCarrier document**. If transferred with the initial eBL envelope transfer, eBLVisualisationByCarrier document must be transferred with every subsequent envelope transfer for the lifetime of the eBL document. Also, eBLVisualisationByCarrier document must be unchanged between different envelope transfers for the lifetime of the eBL document.
     - **Supporting document** (described via entry in the [`EnvelopeManifest.supportingDocuments[]`](#/EnvelopeManifest) list object that has been previously transferred via [**'Start envelope transfer'**](#/Start%20envelope%20transfer) endpoint  as JWS-signed payload of [`EblEnvelope.envelopeManifestSignedContent`](#/EblEnvelope) schema object). For every envelope transfer, the sending platform can choose which supporting documents it wants to send to the receiving platform irrespective of the contents of the previously received envelope transfer. All details of the supporting documents transferred from sending to receiving platform as a part of the envelope transfer are only privy to these 2 platforms.
 
-    <h2>Non-repudiation</h2>
+    <h2>Non-repudiation</h2> 
 
     When receiving [**'Start envelope transfer'**](#/Start%20envelope%20transfer) endpoint request, the receiving platform should confirm the integrity of the received [`EblEnvelope`](#/EblEnvelope) schema object for non-repudiation purposes. Since it has been decided not to use JWS for signing of [`EblEnvelope`](#/EblEnvelope) (for network traffic optimization purposes) itself, the receiving platform can confirm the integrity of the envelope data by confirming integrity of the [`EblEnvelope.envelopeManifestSignedContent`](#/EblEnvelope) JWS-signed payload [`EnvelopeManifest`](#/EnvelopeManifest), and then use contents of [`EnvelopeManifest`](#/EnvelopeManifest) schema object to confirm the integrity of the other [`EblEnvelope`](#/EblEnvelope) schema object attributes (further details can be found in the description of [`EblEnvelope`](#/EblEnvelope) schema attributes).
 
@@ -629,8 +629,6 @@ components:
             - `ETEU` (eTEU)
             - `TRAC` (TRACE Original)
             - `BRIT` (BRITC eBL)
-            
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0.csv).
           example: BOLE
         transportDocumentChecksum:
           type: string
@@ -944,8 +942,6 @@ components:
             - `ETEU` (eTEU)
             - `TRAC` (TRACE Original)
             - `BRIT` (BRITC eBL)
-            
-            Must be a code this list [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/reference-data/eblsolutionproviders-v3.0.0.csv).
           example: BOLE
         identifyingCodes:
           type: array
@@ -1018,7 +1014,8 @@ components:
       title: Tax & Legal Reference
       description: |
         Reference that uniquely identifies a party for tax and/or legal purposes in accordance with the relevant jurisdiction.
-        A list of examples:
+
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -1029,8 +1026,6 @@ components:
         |RUC|PE|Registro Único del Contribuyente in Peru|
         |NIF|MG|Numéro d'Identification Fiscal in Madagascar|
         |NIF|DZ|Numéro d'Identification Fiscal in Algeria|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/taxandlegalreferences-v300.csv).
       properties:
         type:
           type: string
@@ -1046,7 +1041,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: DK
+          example: IN
         value:
           type: string
           pattern: ^\S(?:.*\S)?$
@@ -1322,7 +1317,7 @@ components:
           minLength: 3
           maxLength: 3
           description: |
-            The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217).
+            The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
           example: DKK
         carrierCode:
           type: string
@@ -1682,9 +1677,7 @@ components:
             description: |
               Used by customs to classify the product being shipped. The type of HS code depends on country and customs requirements. The code must be at least 6 and at most 10 digits.
 
-              More information can be found here: [HS Nomenclature 2022 edition](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools/hs-nomenclature-2022-edition/hs-nomenclature-2022-edition.aspx ).
-
-              This standard is based on the 2022 revision.
+              More information can be found here: [HS Nomenclature](https://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools).
             example: '851713'
         nationalCommodityCodes:
           type: array
@@ -1795,7 +1788,7 @@ components:
       description: |
         Reference associated with customs and/or excise purposes required by the relevant authorities for the import, export, or transit of the goods.
 
-        A (small) list of examples:
+        A small list of **potential** examples:
 
         | Type  | Country | Description |
         |-------|:-------:|-------------|
@@ -1804,8 +1797,6 @@ components:
         |ITN|US|Internal Transaction Number in US|
         |PEB|ID|PEB reference number|
         |CSN|IN|Cargo Summary Notification (CSN)|
-
-        Allowed combinations of `type` and `country` are maintained in [GitHub](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/documentation/reference-data/customsreferences-v300.csv).
       properties:
         type:
           type: string
@@ -1821,7 +1812,7 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
-          example: DK
+          example: EG
         values:
           type: array
           minItems: 1
@@ -1944,7 +1935,7 @@ components:
           minLength: 2
           maxLength: 2
           description: |
-            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21 - Revision 12  Annexes V and VI](https://unece.org/sites/default/files/2021-06/rec21_Rev12e_Annex-V-VI_2021.xls)
+            A code identifying the outer packaging/overpack. `PackageCode` must follow the codes specified in [Recommendation N°21](https://unece.org/trade/uncefact/cl-recommendations)
 
             **Condition:** only applicable to dangerous goods if the `IMO packaging code` is not available.
           example: 5H
@@ -1956,7 +1947,7 @@ components:
           description: |
             The code of the packaging as per IMO.
 
-            **Condition:** only applicable to dangerous goods if specified in the IMO IMDG code amendment version 41-22. If not available, the package code as per UN recommendation 21 should be used.
+            **Condition:** only applicable to dangerous goods if specified in the [IMO IMDG code](https://www.imo.org/en/publications/Pages/IMDG%20Code.aspx). If not available, the package code as per UN recommendation 21 should be used.
           example: 1A2
         numberOfPackages:
           type: integer
@@ -2064,8 +2055,6 @@ components:
             - `1.6N` (Extremely insensitive articles which do not have a mass explosion hazard)
             - `2.1` (Flammable gases)
             - `8` (Corrosive substances)
-
-            The value must comply with one of the values in the [DG IMO Class value table](https://github.com/dcsaorg/DCSA-OpenAPI/blob/master/domain/dcsa/reference-data/imoclasses-v3.1.0.csv)
           example: 1.4S
         subsidiaryRisk1:
           type: string
@@ -2422,7 +2411,7 @@ components:
           description: |
             Lowest temperature at which a chemical can vaporize to form an ignitable mixture in air.
             
-            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code amendment version 41-22.
+            **Condition:** only applicable to specific hazardous goods according to the IMO IMDG Code.
           example: 42
         transportControlTemperature:
           type: number
@@ -2535,7 +2524,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://en.wikipedia.org/wiki/ISO_6346) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346:2022](https://www.iso.org/standard/83558.html) standard.
           example: 22GP
         tareWeight:
           type: number
@@ -3004,7 +2993,7 @@ components:
           minLength: 3
           maxLength: 3
           description: |
-            The currency for the charge, using a 3-character code ([ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)).
+            The currency for the charge, using a 3-character code ([ISO 4217](https://www.iso.org/iso-4217-currency-codes.html)).
           example: DKK
         paymentTermCode:
           type: string


### PR DESCRIPTION
[DT-1529](https://dcsa.atlassian.net/browse/DT-1529),[DT-1531](https://dcsa.atlassian.net/browse/DT-1531),[DT-1532](https://dcsa.atlassian.net/browse/DT-1532) - Data validations in Booking and EBL. In general this invloces:
- removing links to GitHub reference data
- removing links to specific versions of externally maintained reference data (and only link to the general page)
- where possible link to ISO instead of Wikipedia

As a side effect - updated some examples.

[DT-1529]: https://dcsa.atlassian.net/browse/DT-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1531]: https://dcsa.atlassian.net/browse/DT-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1532]: https://dcsa.atlassian.net/browse/DT-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ