### PR TITLE
DT-1671,DT-1674: Remove "Party" from location address descriptions

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -3740,24 +3740,24 @@ components:
         street:
           type: string
           maxLength: 70
-          description: The name of the street of the party's address.
+          description: The name of the street.
           example: Ruijggoordweg
         streetNumber:
           type: string
           maxLength: 50
-          description: The number of the street of the party's address.
+          description: The number of the street.
           example: '100'
         floor:
           type: string
           pattern: ^\S(?:.*\S)?$
           maxLength: 50
           description: |
-            The floor of the party's street number.
+            The floor of the street number.
           example: 2nd
         postCode:
           type: string
           maxLength: 10
-          description: The post code of the party's address.
+          description: The post code.
           example: 1047 HM
         PObox:
           type: string
@@ -3769,12 +3769,12 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 35
           description: |
-            The city name of the party's address.
+            The name of the city.
           example: Amsterdam
         stateRegion:
           type: string
           maxLength: 65
-          description: The state/region of the party's address.
+          description: The name of the state/region.
           example: North Holland
         countryCode:
           type: string

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -5639,13 +5639,13 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 35
           description: |
-            The city name of the party’s address.
+            The name of the city.
           example: Amsterdam
         stateRegion:
           type: string
           maxLength: 65
           description: |
-            The state/region of the party’s address.
+            The name of the state/region.
           example: North Holland
         countryCode:
           type: string

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -5576,24 +5576,24 @@ components:
         street:
           type: string
           maxLength: 70
-          description: The name of the street of the party’s address.
+          description: The name of the street.
           example: Ruijggoordweg
         streetNumber:
           type: string
           maxLength: 50
-          description: The number of the street of the party’s address.
+          description: The number of the street.
           example: '100'
         floor:
           type: string
           pattern: ^\S(?:.*\S)?$
           maxLength: 50
           description: |
-            The floor of the party’s street number.
+            The floor of the street number.
           example: N/A
         postCode:
           type: string
           maxLength: 10
-          description: The post code of the party’s address.
+          description: The post code of the address.
           example: 1047 HM
         PObox:
           type: string
@@ -5605,12 +5605,12 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 35
           description: |
-            The city name of the party’s address.
+            The name of the city.
           example: Amsterdam
         stateRegion:
           type: string
           maxLength: 65
-          description: The state/region of the party’s address.
+          description: The name of the state/region.
           example: North Holland
         countryCode:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -2491,24 +2491,24 @@ components:
         street:
           type: string
           maxLength: 70
-          description: The name of the street of the party’s address.
+          description: The name of the street.
           example: Ruijggoordweg
         streetNumber:
           type: string
           maxLength: 50
-          description: The number of the street of the party’s address.
+          description: The number of the street.
           example: '100'
         floor:
           type: string
           pattern: ^\S(?:.*\S)?$
           maxLength: 50
           description: |
-            The floor of the party’s street number.
+            The floor of the street number.
           example: N/A
         postCode:
           type: string
           maxLength: 10
-          description: The post code of the party’s address.
+          description: The post code.
           example: 1047 HM
         PObox:
           type: string
@@ -2520,12 +2520,12 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 35
           description: |
-            The city name of the party’s address.
+            The name of the city.
           example: Amsterdam
         stateRegion:
           type: string
           maxLength: 65
-          description: The state/region of the party’s address.
+          description: The name of the state/region.
           example: North Holland
         countryCode:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -2554,13 +2554,13 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 35
           description: |
-            The city name of the party’s address.
+            The name of the city.
           example: Amsterdam
         stateRegion:
           type: string
           maxLength: 65
           description: |
-            The state/region of the party’s address.
+            The name of the state/region.
           example: North Holland
         countryCode:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -3066,24 +3066,24 @@ components:
         street:
           type: string
           maxLength: 70
-          description: The name of the street of the party’s address.
+          description: The name of the street.
           example: Ruijggoordweg
         streetNumber:
           type: string
           maxLength: 50
-          description: The number of the street of the party’s address.
+          description: The number of the street.
           example: '100'
         floor:
           type: string
           pattern: ^\S(?:.*\S)?$
           maxLength: 50
           description: |
-            The floor of the party’s street number.
+            The floor of the street number.
           example: N/A
         postCode:
           type: string
           maxLength: 10
-          description: The post code of the party’s address.
+          description: The post code.
           example: 1047 HM
         PObox:
           type: string
@@ -3095,12 +3095,12 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 35
           description: |
-            The city name of the party’s address.
+            The name of the city.
           example: Amsterdam
         stateRegion:
           type: string
           maxLength: 65
-          description: The state/region of the party’s address.
+          description: The name of the state/region.
           example: North Holland
         countryCode:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -3129,13 +3129,13 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 35
           description: |
-            The city name of the party’s address.
+            The name of the city.
           example: Amsterdam
         stateRegion:
           type: string
           maxLength: 65
           description: |
-            The state/region of the party’s address.
+            The name of the state/region.
           example: North Holland
         countryCode:
           type: string


### PR DESCRIPTION
[DT-1671](https://dcsa.atlassian.net/browse/DT-1671) - Update City property descriptions to not include "Party" since they are used for locations

[DT-1671]: https://dcsa.atlassian.net/browse/DT-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ