### PR TITLE
APCV-1341-Update DCSA error codes link

### DIFF
--- a/cs/v1/CS_v1.0.0.yaml
+++ b/cs/v1/CS_v1.0.0.yaml
@@ -1706,7 +1706,7 @@ components:
               - `8000-8999` Functional error codes
               - `9000-9999` API provider-specific error codes            
 
-            [Error codes as specified by DCSA](https://dcsa.atlassian.net/wiki/spaces/DTG/pages/197132308/Standard+Error+Codes).
+            [Error codes as specified by DCSA](https://developer.dcsa.org/standard-error-codes).
           example: 7003
           minimum: 7000
           maximum: 9999


### PR DESCRIPTION
Updated the DCSA error codes link to  https://developer.dcsa.org/standard-error-codes