### PR TITLE
DT-1823: Remove required property `surrenderRequestedBy`

### DIFF
--- a/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
+++ b/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
@@ -294,7 +294,6 @@ components:
       required:
         - surrenderRequestReference
         - transportDocumentReference
-        - surrenderRequestedBy
         - surrenderRequestCode
     IdentifyingCode:
       type: object


### PR DESCRIPTION
[DT-1823](https://dcsa.atlassian.net/browse/DT-1823): Remove `surrenderRequestedBy` as a required proeprty as it is not part of the object it is mentioned in

[DT-1823]: https://dcsa.atlassian.net/browse/DT-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ