### PR TITLE
DT-1836: Remove conditions linking to multiple bookings from TD

### DIFF
--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -5346,17 +5346,6 @@ components:
           # Extended description of carrierBookingReference compared to DCSA_DOMAIN description
           description: |
             The associated booking number provided by the carrier for this `Consignment Item`.
-
-            When multiple `carrierBookingReferences` are used then the bookings referred to must all contain the same:
-            - transportPlan
-            - shipmentLocations
-            - receiptTypeAtOrigin
-            - deliveryTypeAtDestination
-            - cargoMovementTypeAtOrigin
-            - cargoMovementTypeAtDestination
-            - serviceContractReference
-            - termsAndConditions
-            - Place of B/L Issue (if provided)
           example: ABC709951
         descriptionOfGoods:
           type: array
@@ -5442,17 +5431,6 @@ components:
           # Extended description of carrierBookingReference compared to DCSA_DOMAIN description
           description: |
             The associated booking number provided by the carrier for this `Consignment Item`.
-
-            When multiple `carrierBookingReferences` are used then the bookings referred to must all contain the same:
-            - transportPlan
-            - shipmentLocations
-            - receiptTypeAtOrigin
-            - deliveryTypeAtDestination
-            - cargoMovementTypeAtOrigin
-            - cargoMovementTypeAtDestination
-            - serviceContractReference
-            - termsAndConditions
-            - Place of B/L Issue (if provided)
           example: ABC709951
         commoditySubreference:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -1065,17 +1065,6 @@ components:
           # Extended description of carrierBookingReference compared to DCSA_DOMAIN description
           description: |
             The associated booking number provided by the carrier for this `Consignment Item`.
-
-            When multiple `carrierBookingReferences` are used then the bookings referred to must all contain the same:
-            - transportPlan
-            - shipmentLocations
-            - receiptTypeAtOrigin
-            - deliveryTypeAtDestination
-            - cargoMovementTypeAtOrigin
-            - cargoMovementTypeAtDestination
-            - serviceContractReference
-            - termsAndConditions
-            - Place of B/L Issue (if provided)
           example: ABC709951
         descriptionOfGoods:
           type: array

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1606,17 +1606,6 @@ components:
           # Extended description of carrierBookingReference compared to DCSA_DOMAIN description
           description: |
             The associated booking number provided by the carrier for this `Consignment Item`.
-
-            When multiple `carrierBookingReferences` are used then the bookings referred to must all contain the same:
-            - transportPlan
-            - shipmentLocations
-            - receiptTypeAtOrigin
-            - deliveryTypeAtDestination
-            - cargoMovementTypeAtOrigin
-            - cargoMovementTypeAtDestination
-            - serviceContractReference
-            - termsAndConditions
-            - Place of B/L Issue (if provided)
           example: ABC709951
         descriptionOfGoods:
           type: array


### PR DESCRIPTION
[DT-1836](https://dcsa.atlassian.net/browse/DT-1836),[DT-1838](https://dcsa.atlassian.net/browse/DT-1838): Remove the condition on `carrierBookingReference` as it is currently "Out of Scope" for DCSA to define the requirements for combined bookings

[DT-1836]: https://dcsa.atlassian.net/browse/DT-1836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1838]: https://dcsa.atlassian.net/browse/DT-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ