### PR TITLE
DT-1858: Add a condition to `declaredValueCurrency`

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -3012,6 +3012,8 @@ components:
           maxLength: 3
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
+
+            **Condition:** Mandatory if `declaredValue` is provided
           example: DKK
         carrierCode:
           type: string
@@ -3313,6 +3315,8 @@ components:
           maxLength: 3
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
+
+            **Condition:** Mandatory if `declaredValue` is provided
           example: DKK
         carrierCode:
           type: string
@@ -3681,6 +3685,8 @@ components:
           maxLength: 3
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
+
+            **Condition:** Mandatory if `declaredValue` is provided
           example: DKK
         carrierCode:
           type: string

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -7535,6 +7535,8 @@ components:
           maxLength: 3
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
+
+            **Condition:** Mandatory if `declaredValue` is provided
           example: DKK
         carrierCode:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -824,6 +824,8 @@ components:
           maxLength: 3
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
+
+            **Condition:** Mandatory if `declaredValue` is provided
           example: DKK
         carrierCode:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1365,6 +1365,8 @@ components:
           maxLength: 3
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
+
+            **Condition:** Mandatory if `declaredValue` is provided
           example: DKK
         carrierCode:
           type: string


### PR DESCRIPTION
[DT-1858](https://dcsa.atlassian.net/browse/DT-1858): Add a condition to `declaredValueCurrency` to make it mandatory if `declaredValue` is provided

[DT-1858]: https://dcsa.atlassian.net/browse/DT-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ