### PR TITLE
SD-652: Update the Surrender API description

### DIFF
--- a/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
+++ b/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
@@ -14,7 +14,7 @@ info:
     
         POST /v3/ebl-surrender-requests
     
-    which will be processed asynchronously. Responses to the surrender requests will be submitted by the carrier via 
+    which will be processed asynchronously. The EBL Solution Platform submitting the surrender request to the carrier must be the same EBL Solution Platform from which the eBL was issued. Responses to the surrender requests will be submitted by the carrier via 
     
         POST /v3/ebl-surrender-responses
 


### PR DESCRIPTION
[SD-652](https://dcsa.atlassian.net/browse/SD-652): Update the Surrender API description to indicate that a B/L must be surrendered from the same Solution Platform (SP) as it was Issued to.

@palatsangeetha lets merge this. If the PO comes back and wants to modify the description - then a new issue should be made

[SD-652]: https://dcsa.atlassian.net/browse/SD-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ