### PR TITLE
SD-633: Change the wording "either" to "one of" to be more precise

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -554,7 +554,7 @@ paths:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
       description: |
-        Updates the `Booking Request` with the `bookingReference`. The path can contain either a `carrierBookingRequestReference` or a `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with either
+        Updates the `Booking Request` with the `bookingReference`. The path can contain one of a `carrierBookingRequestReference` or a `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with one of
         - **UseCase 3 - Submit updated Booking request**
         - **UseCase 7 - Request amendments to confirmed Booking**
 
@@ -613,7 +613,7 @@ paths:
 
             GET /v2/bookings/{bookingReference}?amendedContent=true
 
-        It is possible to `GET` the content of the `Amended Booking` via the example above until either:
+        It is possible to `GET` the content of the `Amended Booking` via the example above until one of:
 
         - the provider requests for a new amendment (**UseCase 6: Request to amend confirmed Booking**) in which case the "old update" is no longer accessible
         - the consumer submits a new update (**UseCase 7: Request amendment to confirmed Booking**) in which case the "new amendment" provided **replaces** the "old amendment".
@@ -1516,7 +1516,7 @@ paths:
         This endPoint corresponds with **UseCase 11 - Cancel Booking Request by shipper**, **UseCase 9 - Cancel amendment to confirmed Booking** or **UseCase 13 - Cancel confirmed Booking by shipper**.
 
         ## Precondition
-        In order to cancel a `Booking`, the `bookingStatus` must be either
+        In order to cancel a `Booking`, the `bookingStatus` must be one of
         - `RECEIVED`
         - `PENDING_UPDATE`
         - `UPDATE_RECEIVED`
@@ -2809,7 +2809,7 @@ components:
       title: Facility
       type: object
       description: |
-        An object used to express a location using a `Facility`. The facility can either be expressed using a `BIC` code or a `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
+        An object used to express a location using a `Facility`. The facility can be expressed using one of `BIC` code or `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
       properties:
         facilityCode:
           type: string
@@ -2924,7 +2924,7 @@ components:
           description: |
             Reference number for agreement between shipper and carrier, which optionally includes a certain minimum quantity commitment (usually referred as “MQC”) of cargo that the shipper commits to over a fixed period, and the carrier commits to a certain rate or rate schedule.
             
-            **Condition:** Either a valid `serviceContractReference` or `contractQuotationReference` must be provided.
+            **Condition:** One of `serviceContractReference` or `contractQuotationReference` must be provided, but not both.
           example: HHL51800000
         freightPaymentTermCode:
           type: string
@@ -2947,7 +2947,7 @@ components:
           description: |
             Information provided by the shipper to identify whether pricing for the shipment has been agreed via a contract or a quotation reference.
 
-            **Condition:** Either a valid `contractQuotationReference` or `serviceContractReference` must be provided.
+            **Condition:** One of `contractQuotationReference` or `serviceContractReference` must be provided, but not both.
           example: HHL1401
         vessel:
           $ref: '#/components/schemas/Vessel'
@@ -3228,7 +3228,7 @@ components:
           description: |
             Reference number for agreement between shipper and carrier, which optionally includes a certain minimum quantity commitment (usually referred as “MQC”) of cargo that the shipper commits to over a fixed period, and the carrier commits to a certain rate or rate schedule.
             
-            **Condition:** Either a valid `serviceContractReference` or `contractQuotationReference` must be provided.
+            **Condition:** One of `serviceContractReference` or `contractQuotationReference` must be provided, but not both.
           example: HHL51800000
         freightPaymentTermCode:
           type: string
@@ -3251,7 +3251,7 @@ components:
           description: |
             Information provided by the shipper to identify whether pricing for the shipment has been agreed via a contract or a quotation reference.
 
-            **Condition:** Either a valid `contractQuotationReference` or `serviceContractReference` must be provided.
+            **Condition:** One of `contractQuotationReference` or `serviceContractReference` must be provided, but not both.
           example: HHL1401
         vessel:
           $ref: '#/components/schemas/Vessel'
@@ -3598,7 +3598,7 @@ components:
           description: |
             Reference number for agreement between shipper and carrier, which optionally includes a certain minimum quantity commitment (usually referred as “MQC”) of cargo that the shipper commits to over a fixed period, and the carrier commits to a certain rate or rate schedule.
             
-            **Condition:** Either a valid `serviceContractReference` or `contractQuotationReference` must be provided.
+            **Condition:** One of `serviceContractReference` or `contractQuotationReference` must be provided, but not both.
           example: HHL51800000
         freightPaymentTermCode:
           type: string
@@ -3621,7 +3621,7 @@ components:
           description: |
             Information provided by the shipper to identify whether pricing for the shipment has been agreed via a contract or a quotation reference.
 
-            **Condition:** Either a valid `contractQuotationReference` or `serviceContractReference` must be provided.
+            **Condition:** One of `contractQuotationReference` or `serviceContractReference` must be provided, but not both.
           example: HHL1401
         vessel:
           $ref: '#/components/schemas/Vessel'
@@ -3930,7 +3930,7 @@ components:
       description: |
         An object to capture where the original Transport Document (`Bill of Lading`) will be issued.
 
-        The location can be specified either as a `UN Location Code` or as a `CountryCode`.
+        The location can be specified as one of `UN Location Code` or `CountryCode`, but not both.
       properties:
         locationName:
           type: string
@@ -4478,7 +4478,7 @@ components:
       type: object
       title: Party Contact Detail
       description: |
-        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`.
+        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`, both can be provided.
       example:
         name: Henrik
         phone: +45 51801234
@@ -4809,7 +4809,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22RT
         units:
           type: integer
@@ -4895,7 +4895,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22RT
         units:
           type: integer
@@ -5345,7 +5345,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -5375,7 +5375,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -5403,8 +5403,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
-            
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -5432,7 +5431,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -5460,8 +5459,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
-            
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -5590,7 +5588,7 @@ components:
       type: object
       title: Dangerous Goods
       description: |
-        Specification for `Dangerous Goods`. It is mandatory to either provide the `UNNumber` or the `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
+        Specification for `Dangerous Goods`. It is mandatory to provide one of `UNNumber` or `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
       oneOf:
         - type: object
           title: UN Number
@@ -5851,8 +5849,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -5879,8 +5876,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netWeight`. Possible values are
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -5907,8 +5903,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netExplosiveWeight`. Possible values are
-
+            Unit of measure used to describe the `netExplosiveWeight`. Possible values are:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
             - `GRM` (Grams)
@@ -5941,8 +5936,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
             - `LTR` (Litre)
@@ -6081,7 +6075,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22G1
         units:
           type: integer

--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -554,7 +554,7 @@ paths:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
       description: |
-        Updates the `Booking Request` with the `bookingReference`. The path can contain one of a `carrierBookingRequestReference` or a `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with one of
+        Updates the `Booking Request` with the `bookingReference`. The path can contain one of `carrierBookingRequestReference` or `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with one of
         - **UseCase 3 - Submit updated Booking request**
         - **UseCase 7 - Request amendments to confirmed Booking**
 

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -4397,7 +4397,7 @@ components:
       description: |
         The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
 
-        **Condition:** Either the `address` or the `displayedAddress` must be included in the `Transport Document`.
+        **Condition:** One of `address` or `displayedAddress` must be included in the `Transport Document`, but not both.
       properties:
         partyName:
           type: string

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -4437,6 +4437,8 @@ components:
             example: Strawinskylaan 4117
         identifyingCodes:
           type: array
+          description: |
+            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:
@@ -4565,6 +4567,8 @@ components:
             example: Strawinskylaan 4117
         identifyingCodes:
           type: array
+          description: |
+            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:
@@ -4683,6 +4687,8 @@ components:
             example: Strawinskylaan 4117
         identifyingCodes:
           type: array
+          description: |
+            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:
@@ -4820,6 +4826,8 @@ components:
             example: Strawinskylaan 4117
         identifyingCodes:
           type: array
+          description: |
+            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:
@@ -5001,6 +5009,8 @@ components:
           $ref: '#/components/schemas/PartyAddress'
         identifyingCodes:
           type: array
+          description: |
+            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:
@@ -5071,6 +5081,8 @@ components:
       title: Issuing Party
       description: |
         The company or a legal entity issuing the `Transport Document`.
+
+        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`.
       properties:
         partyName:
           type: string
@@ -5083,6 +5095,8 @@ components:
           $ref: '#/components/schemas/PartyAddress'
         identifyingCodes:
           type: array
+          description: |
+            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -4326,7 +4326,7 @@ components:
       type: object
       title: Party Address
       description: |
-        An object for storing address related information
+        Address where the party is located. It is an object of the attributes below.
       properties:
         street:
           type: string
@@ -4397,7 +4397,7 @@ components:
       description: |
         The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
 
-        **Condition:** One of `address` or `displayedAddress` must be included in the `Transport Document`, but not both.
+        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`. If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -4524,6 +4524,8 @@ components:
         The party to which goods are consigned in the `Master Bill of Lading`.
         
         **Condition:** Mandatory for non-negotiable BL (`isToOrder=false`)
+
+        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`. If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -4650,6 +4652,8 @@ components:
         The party to whom the title to the goods is transferred by means of endorsement.
         
         **Condition:** Can only be provided for negotiable BLs (`isToOrder=true`). If a negotiable BL does not have an `Endorsee`, the BL is said to be "blank endorsed". Note `Consignee` and `Endorsee` are mutually exclusive.
+
+        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`. If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -4775,6 +4779,8 @@ components:
       title: Notify Party
       description: |
         The person to be notified when a shipment arrives at its destination.
+
+        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`. If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -4981,6 +4987,8 @@ components:
       title: Party
       description: |
         Refers to a company or a legal entity.
+
+        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`.
       properties:
         partyName:
           type: string
@@ -5062,7 +5070,7 @@ components:
       type: object
       title: Issuing Party
       description: |
-        Refers to a company or a legal entity.
+        The company or a legal entity issuing the `Transport Document`.
       properties:
         partyName:
           type: string

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -304,7 +304,7 @@ paths:
         - $ref: '#/components/parameters/documentReference'
         - $ref: '#/components/parameters/Api-Version-Major'
       description: |
-        Updates the `Shipping Instructions` with the `documentReference`. The path can contain either a `shippingInstructionsReference` or a `transportDocumentReference`. This endPoint corresponds with **UseCase 3 - Submit updated Shipping Instructions**
+        Updates the `Shipping Instructions` with the `documentReference`. The path can contain one of a `shippingInstructionsReference` or a `transportDocumentReference`. This endPoint corresponds with **UseCase 3 - Submit updated Shipping Instructions**
 
         ### Precondition
         In order to update a `Shipping Instructions`, the status of the `Shipping Instructions` needs to be in state:
@@ -349,7 +349,7 @@ paths:
           
             GET /v3/shipping-instructions/{documentReference}?updatedContent=true
             
-        It is possible to `GET` the content of the `Updated Shipping Instructions` via the example above until either:
+        It is possible to `GET` the content of the `Updated Shipping Instructions` via the example above until one of:
           - the provider requests for a new update (**UseCase 2: Request to update Shipping Instructions**) in which case the "old update" is no longer accessible
           - the consumer submits a new update (**UseCase 3: Submit updated Shipping Instructions**) in which case the "new update" provided **replaces** the "old update".
       requestBody:
@@ -963,7 +963,7 @@ paths:
         A way for the consumer to Cancel an `Updated Shipping Instructions`. This endPoint corresponds with **UseCase 5 - Cancel update to Shipping Instructions**.
 
         ## Precondition
-        In order to cancel an `Updated Shipping Instructions`, the status of the `Updated Shipping Instructions` must be in in status `UPDATE_RECEIVED`. The status of the `Shipping Instructions` can be either `RECEIVED` or `PENDING_UPDATE`.
+        In order to cancel an `Updated Shipping Instructions`, the status of the `Updated Shipping Instructions` must be in in status `UPDATE_RECEIVED`. The status of the `Shipping Instructions` can be one of `RECEIVED` or `PENDING_UPDATE`.
 
         ## Postcondition
         The provider has received a cancellation from the consumer for an `Updated Shipping Instructions` that is in state `UPDATE_RECEIVED`.
@@ -2625,7 +2625,7 @@ components:
       in: path
       name: documentReference
       description: |
-        An identifier for a `Shipping Instructions`. It can either be a `shippingInstructionsReference` or a `transportDocumentReference`.
+        An identifier for a `Shipping Instructions`. It can be one of `shippingInstructionsReference` or `transportDocumentReference`.
       schema:
         type: string
         pattern: ^\S(?:.*\S)?$
@@ -4218,7 +4218,7 @@ components:
       type: object
       title: Facility
       description: |
-        An object used to express a location using a `Facility`. The facility can either be expressed using a `BIC` code or a `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
+        An object used to express a location using a `Facility`. The facility can be expressed using one of `BIC` code or `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
       properties:
         facilityCode:
           type: string
@@ -5097,7 +5097,7 @@ components:
       type: object
       title: Party Contact Detail
       description: |
-        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`.
+        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`, both can be provided.
       example:
         name: Henrik
         phone: +45 51801234
@@ -5145,7 +5145,7 @@ components:
       type: object
       title: Party Contact Detail (House B/L)
       description: |
-        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`.
+        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`, both can be provided.
       example:
         name: Henrik
         phone: +45 51801234
@@ -5820,7 +5820,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -5847,7 +5847,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -5874,7 +5874,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -5901,7 +5901,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -6080,7 +6080,7 @@ components:
       type: object
       title: Dangerous Goods
       description: |
-        Specification for `Dangerous Goods`. It is mandatory to either provide the `UNNumber` or the `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
+        Specification for `Dangerous Goods`. It is mandatory to provide one of `UNNumber` or `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
       oneOf:
         - type: object
           title: UN Number
@@ -6321,8 +6321,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -6349,8 +6348,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netWeight`. Possible values are
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -6377,8 +6375,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netExplosiveWeight`. Possible values are
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
             - `GRM` (Grams)
@@ -6411,8 +6408,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
             - `LTR` (Litre)
@@ -6704,7 +6700,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22G1
       required:
         - emptyIndicatorCode
@@ -6777,7 +6773,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22G1
         tareWeight:
           $ref: '#/components/schemas/TareWeight'
@@ -6833,7 +6829,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22G1
         tareWeight:
           $ref: '#/components/schemas/TareWeight'
@@ -7018,7 +7014,7 @@ components:
 
             In case of self-filing (`SELF`), the shipper can provide their `selfFilerCode` for each manifest.
 
-            **Condition:** The `selfFilerCode` must be provided when `manifestTypeCode` is either `ACE` (US) or `ACI` (CA) and the `advanceManifestFilingsHouseBLPerformedBy` is set to `SELF`.
+            **Condition:** The `selfFilerCode` must be provided when `manifestTypeCode` is one of `ACE` (US) or `ACI` (CA) and the `advanceManifestFilingsHouseBLPerformedBy` is set to `SELF`.
           enum:
             - SELF
             - CARRIER
@@ -7030,7 +7026,7 @@ components:
           description: |
             Code identifying the party who will submit the advance manifest filing(s) for the House BL.
 
-            **Mandatory** if `manifestTypeCode` is either `ACE` (US) or `ACI` (CA) and `advanceManifestFilingsHouseBLPerformedBy` is set to `SELF`.
+            **Mandatory** if `manifestTypeCode` is one of `ACE` (US) or `ACI` (CA) and `advanceManifestFilingsHouseBLPerformedBy` is set to `SELF`.
           example: FLXP
         identificationNumber:
           type: string
@@ -7145,7 +7141,7 @@ components:
 
         **Condition:** Mandatory if different from `Place of Receipt` or `Port of Loading` at the `Master Transport Document` level.
 
-        The location can be specified either using `UN Location Code` and/or `Location Name` together with `Country Code`.
+        **Condition:** The location can be specified either using `UN Location Code` and/or (`Location Name` together with `Country Code`), all three properties can be specified.
       example:
         locationName: Hamburg
         UNLocationCode: DEHAM
@@ -7191,7 +7187,7 @@ components:
         
         **Condition:** Mandatory if different from `Place of Delivery` at the `Master Transport Document` level.
 
-        The location can be specified either using `UN Location Code` and/or `Location Name` together with `Country Code`.
+        **Condition:** The location can be specified either using `UN Location Code` and/or (`Location Name` together with `Country Code`), all three properties can be specified.
       example:
         locationName: Hamburg
         UNLocationCode: DEHAM
@@ -8090,7 +8086,7 @@ components:
       description: |
         An object to capture where the original Transport Document (`Bill of Lading`) will be issued.
 
-        The location can be specified either as a `UN Location Code` or as a `CountryCode`.
+        The location can be specified as one of `UN Location Code` or `CountryCode`.
       properties:
         locationName:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -2796,7 +2796,7 @@ components:
       description: |
         The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
 
-        **Condition:** Either the `address` or the `displayedAddress` must be included in the `Transport Document`.
+        **Condition:** One of `address` or `displayedAddress` must be included in the `Transport Document`, but not both.
       properties:
         partyName:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -943,7 +943,7 @@ components:
       type: object
       title: Party Contact Detail
       description: |
-        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`.
+        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`, both can be provided.
       example:
         name: Henrik
         phone: +45 51801234
@@ -1319,7 +1319,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -1346,7 +1346,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -1373,7 +1373,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -1400,7 +1400,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -1481,7 +1481,7 @@ components:
       type: object
       title: Dangerous Goods
       description: |
-        Specification for `Dangerous Goods`. It is mandatory to either provide the `UNNumber` or the `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
+        Specification for `Dangerous Goods`. It is mandatory to provide one of `UNNumber` or `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
       oneOf:
         - type: object
           title: UN Number
@@ -1722,8 +1722,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -1750,8 +1749,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netWeight`. Possible values are
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -1778,8 +1776,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netExplosiveWeight`. Possible values are
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
             - `GRM` (Grams)
@@ -1812,8 +1809,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
             - `LTR` (Litre)
@@ -2025,7 +2021,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22G1
         tareWeight:
           $ref: '#/components/schemas/TareWeight'
@@ -2649,7 +2645,7 @@ components:
       type: object
       title: Facility
       description: |
-        An interface used to express a location using a `Facility`. The facility can either be expressed using a `BIC` code or a `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
+        An interface used to express a location using a `Facility`. The facility can be expressed using one of `BIC` code or `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
       properties:
         facilityCode:
           type: string
@@ -3262,7 +3258,7 @@ components:
       description: |
         An object to capture where the original Transport Document (`Bill of Lading`) will be issued.
 
-        The location can be specified either as a `UN Location Code` or as a `CountryCode`.
+        The location can be specified as one of `UN Location Code` or `CountryCode`.
       properties:
         locationName:
           type: string

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -2796,7 +2796,7 @@ components:
       description: |
         The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
 
-        **Condition:** One of `address` or `displayedAddress` must be included in the `Transport Document`, but not both.
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -2878,6 +2878,8 @@ components:
         The party to which goods are consigned in the `Master Bill of Lading`.
         
         **Condition:** Mandatory for non-negotiable BL (`isToOrder=false`)
+
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -2959,6 +2961,8 @@ components:
         The party to whom the title to the goods is transferred by means of endorsement.
         
         **Condition:** Can only be provided for negotiable BLs (`isToOrder=true`). If a negotiable BL does not have an `Endorsee`, the BL is said to be "blank endorsed". Note `Consignee` and `Endorsee` are mutually exclusive.
+
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -3036,6 +3040,8 @@ components:
       title: Notify Party
       description: |
         The person to be notified when a shipment arrives at its destination.
+
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -3144,7 +3150,7 @@ components:
       type: object
       title: Issuing Party
       description: |
-        Refers to a company or a legal entity.
+        The company or a legal entity issuing the `Transport Document`
       properties:
         partyName:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1488,7 +1488,7 @@ components:
       type: object
       title: Party Contact Detail
       description: |
-        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`.
+        The contact details of the person to contact. It is mandatory to provide either `phone` and/or `email` along with the `name`, both can be provided.
       example:
         name: Henrik
         phone: +45 51801234
@@ -1864,7 +1864,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -1891,7 +1891,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -1918,7 +1918,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -1945,7 +1945,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
           enum:
@@ -2026,7 +2026,7 @@ components:
       type: object
       title: Dangerous Goods
       description: |
-        Specification for `Dangerous Goods`. It is mandatory to either provide the `UNNumber` or the `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
+        Specification for `Dangerous Goods`. It is mandatory to provide one of `UNNumber` or `NANumber`. Dangerous Goods is based on **IMDG Amendment Version 41-22**.
       oneOf:
         - type: object
           title: UN Number
@@ -2267,8 +2267,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -2295,8 +2294,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netWeight`. Possible values are
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
           enum:
@@ -2323,8 +2321,7 @@ components:
         unit:
           type: string
           description: |
-            Unit of measure used to describe the `netExplosiveWeight`. Possible values are
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `KGM` (Kilograms)
             - `LBR` (Pounds)
             - `GRM` (Grams)
@@ -2357,8 +2354,7 @@ components:
         unit:
           type: string
           description: |
-            The unit of measure which can be expressed in either imperial or metric terms
-
+            The unit of measure which can be expressed in imperial or metric terms:
             - `FTQ` (Cubic foot)
             - `MTQ` (Cubic meter)
             - `LTR` (Litre)
@@ -2570,7 +2566,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 4
           description: |
-            Unique code for the different equipment size and type used to transport commodities. The code can refer to either the ISO size type (e.g. 22G1) or the ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
+            Unique code for the different equipment size and type used to transport commodities. The code can refer to one of ISO size type (e.g. 22G1) or ISO type group (e.g. 22GP) following the [ISO 6346](https://www.iso.org/standard/83558.html) standard.
           example: 22GP
         tareWeight:
           $ref: '#/components/schemas/TareWeight'
@@ -3193,7 +3189,7 @@ components:
       type: object
       title: Facility
       description: |
-        An object used to express a location using a `Facility`. The facility can either be expressed using a `BIC` code or a `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
+        An object used to express a location using a `Facility`. The facility can be expressed using one of `BIC` code or `SMDG` code. The `facilityCode` does not contain the `UNLocationCode` - this should be provided in the `UnLocationCode` attribute.
       properties:
         facilityCode:
           type: string
@@ -3729,7 +3725,7 @@ components:
       description: |
         An object to capture where the original Transport Document (`Bill of Lading`) will be issued.
 
-        The location can be specified either as a `UN Location Code` or as a `CountryCode`.
+        The location can be specified as one of `UN Location Code` or `CountryCode`.
       properties:
         locationName:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -3340,7 +3340,7 @@ components:
       description: |
         The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
 
-        **Condition:** One of `address` or `displayedAddress` must be included in the `Transport Document`, but not both.
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -3422,6 +3422,8 @@ components:
         The party to which goods are consigned in the `Master Bill of Lading`.
         
         **Condition:** Mandatory for non-negotiable BL (`isToOrder=false`)
+
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -3503,6 +3505,8 @@ components:
         The party to whom the title to the goods is transferred by means of endorsement.
         
         **Condition:** Can only be provided for negotiable BLs (`isToOrder=true`). If a negotiable BL does not have an `Endorsee`, the BL is said to be "blank endorsed". Note `Consignee` and `Endorsee` are mutually exclusive.
+
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -3580,6 +3584,8 @@ components:
       title: Notify Party
       description: |
         The person to be notified when a shipment arrives at its destination.
+
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -3688,7 +3694,7 @@ components:
       type: object
       title: Issuing Party
       description: |
-        Refers to a company or a legal entity.
+        The company or a legal entity issuing the `Transport Document`
       properties:
         partyName:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -3340,7 +3340,7 @@ components:
       description: |
         The party by whom or in whose name or on whose behalf a contract of carriage of goods by sea has been concluded with a carrier, or the party by whom or in whose name, or on whose behalf, the goods are actually delivered to the carrier in relation to the contract of carriage by sea.
 
-        **Condition:** Either the `address` or the `displayedAddress` must be included in the `Transport Document`.
+        **Condition:** One of `address` or `displayedAddress` must be included in the `Transport Document`, but not both.
       properties:
         partyName:
           type: string


### PR DESCRIPTION
[SD-633](https://dcsa.atlassian.net/browse/SD-633),[SD-1489](https://dcsa.atlassian.net/browse/SD-1489): Make sure it is clear that only one of the two options is allowed (when applicable) - hence changing the wording "either" to "one of" to make it more clear.
Side fix: aligning how `unit` is described across the APIs
Adding extra conditions as requested by PO

[SD-633]: https://dcsa.atlassian.net/browse/SD-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SD-1489]: https://dcsa.atlassian.net/browse/SD-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ