### PR TITLE
SD-1759: Fix wrong O^2 description

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -4029,7 +4029,7 @@ components:
           minimum: 0
           maximum: 100
           description: |
-            The percentage of the controlled atmosphere CO<sub>2</sub> target value
+            The percentage of the controlled atmosphere O<sub>2</sub> target value
           example: 25
         co2Setpoint:
           type: number

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -7076,7 +7076,7 @@ components:
           minimum: 0
           maximum: 100
           description: |
-            The percentage of the controlled atmosphere CO<sub>2</sub> target value
+            The percentage of the controlled atmosphere O<sub>2</sub> target value
           example: 25
         co2Setpoint:
           type: number

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -2131,7 +2131,7 @@ components:
           minimum: 0
           maximum: 100
           description: |
-            The percentage of the controlled atmosphere CO<sub>2</sub> target value
+            The percentage of the controlled atmosphere O<sub>2</sub> target value
           example: 25
         co2Setpoint:
           type: number

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -2675,7 +2675,7 @@ components:
           minimum: 0
           maximum: 100
           description: |
-            The percentage of the controlled atmosphere CO<sub>2</sub> target value
+            The percentage of the controlled atmosphere O<sub>2</sub> target value
           example: 25
         co2Setpoint:
           type: number


### PR DESCRIPTION
[SD-1759](https://dcsa.atlassian.net/browse/SD-1759): Fix copy/paste error in O^2 description

[SD-1759]: https://dcsa.atlassian.net/browse/SD-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ