### PR TITLE
SD-1702: Add `GeoCoordinate` to the description

### DIFF
--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -7911,7 +7911,7 @@ components:
 
         **Condition:** Only when pre-carriage is done by the carrier.
 
-        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility` or an `Address`.
+        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility`, `Address` or a `Geo Coordinate`.
 
         **Condition:** It is expected that if a location is specified in multiple ways (e.g. both as an `Address` and as a `Facility`) that both ways point to the same location.
       example:
@@ -8019,7 +8019,7 @@ components:
 
         **Condition:** Only when onward transport is done by the carrier
 
-        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility` or an `Address`.
+        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility`, `Address` or a `Geo Coordinate`.
 
         **Condition:** It is expected that if a location is specified in multiple ways (e.g. both as an `Address` and as a `Facility`) that both ways point to the same location.
       example:

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -2300,7 +2300,7 @@ components:
 
         **Condition:** Only when pre-carriage is done by the carrier.
 
-        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility` or an `Address`.
+        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility`, `Address` or a `Geo Coordinate`.
 
         **Condition:** It is expected that if a location is specified in multiple ways (e.g. both as an `Address` and as a `Facility`) that both ways point to the same location.
       example:
@@ -2408,7 +2408,7 @@ components:
 
         **Condition:** Only when onward transport is done by the carrier
 
-        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility` or an `Address`.
+        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility`, `Address` or a `Geo Coordinate`.
 
         **Condition:** It is expected that if a location is specified in multiple ways (e.g. both as an `Address` and as a `Facility`) that both ways point to the same location.
       example:

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -2844,7 +2844,7 @@ components:
 
         **Condition:** Only when pre-carriage is done by the carrier.
 
-        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility` or an `Address`.
+        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility`, `Address` or a `Geo Coordinate`.
 
         **Condition:** It is expected that if a location is specified in multiple ways (e.g. both as an `Address` and as a `Facility`) that both ways point to the same location.
       example:
@@ -2952,7 +2952,7 @@ components:
 
         **Condition:** Only when onward transport is done by the carrier
 
-        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility` or an `Address`.
+        The location can be specified in **any** of the following ways: `UN Location Code`, `Facility`, `Address` or a `Geo Coordinate`.
 
         **Condition:** It is expected that if a location is specified in multiple ways (e.g. both as an `Address` and as a `Facility`) that both ways point to the same location.
       example:


### PR DESCRIPTION
[SD-1702](https://dcsa.atlassian.net/browse/SD-1702): Add missing `GeoCoordinate` to the description of `Place of Receipt` and  `Place of Delivery`