### PR TITLE
SD-1701: Add `null` to value-property in endPoints with empty responses

### DIFF
--- a/bkg/v2/BKG_v2.0.0.yaml
+++ b/bkg/v2/BKG_v2.0.0.yaml
@@ -950,7 +950,7 @@ paths:
                     Booking request updated with no content
                   description: |
                     An updated `Booking request` received, schema validated and accepted by provider - the `Booking` now awaits provider action, `bookingStatus` does not change.
-                  value:
+                  value: null
         '400':
           description: |
             In case the updated/amended `Booking request` does not schema validate a `400` (Bad Request) is returned
@@ -1590,19 +1590,19 @@ paths:
                     Booking Request cancelled
                   description: |
                     The consumer has requested that the `Booking Request` should be cancelled. The cancellation request has been accepted and is now awaiting further processing by the provider
-                  value:
+                  value: null
                 amendmentCancelledExample:
                   summary: |
                     Amendment cancellation on a confirmed Booking accepted
                   description: |
                     The consumer has requested that the amendment to a confirmed `Booking` is to be cancelled. The cancellation request as been accepted and is now awaiting further processing by the provider
-                  value:
+                  value: null
                 confirmedBookingCancellationExample:
                   summary: |
                     Request to Cancel a confirmed Booking accepted
                   description: |
                     The consumer has requested to cancel a confirmed `Booking`. The cancellation request has been accepted and is now awaiting further processing by the provider
-                  value:
+                  value: null
         '400':
           description: |
             In case the cancel payload does not schema validate a `400` (Bad Request) is returned

--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -426,7 +426,7 @@ paths:
                     Shipping Instructions updated by consumer
                   description: |
                     An `Updated Shipping Instructions` received and accepted by provider, the `Updated Shipping Instructions` now awaits provider action, the `shippingInstructionStatus` does not change.
-                  value:
+                  value: null
         '400':
           description: |
             In case the updated `Shipping Instructions` does not schema validate a `400` (Bad Request) is returned
@@ -1019,7 +1019,7 @@ paths:
                     Cancel a Shipping Instructions update
                   description: |
                     Consumer wants to cancel an update provided to a `Shipping Instructions`.
-                  value:
+                  value: null
         '400':
           description: |
             In case the cancel payload does not schema validate a `400` (Bad Request) is returned
@@ -1722,7 +1722,7 @@ paths:
                     Approve Draft Transport Document
                   description: |
                     Consumer approves the drafted `Transport Document` and now awaits further processing by provider.
-                  value:
+                  value: null
         '400':
           description: |
             In case the Approve payload does not schema validate a `400` (Bad Request) is returned


### PR DESCRIPTION
[SD-1701](https://dcsa.atlassian.net/browse/SD-1701): It is **not** possible in SwaggerHub to avoid endPoints with empty payloads to not be renendered. To make it more explicit this PR makes sure to add the `null` next to the value property in the example.
<img width="538" alt="image" src="https://github.com/user-attachments/assets/1a448d68-5fde-4976-9c84-d13b6abe3c62">


[SD-1701]: https://dcsa.atlassian.net/browse/SD-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ