### PR TITLE
SD-1736: Convert `EBL` to `eBL`

### DIFF
--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -18,9 +18,9 @@ info:
 
     For explanation of specific values or objects please refer to the [Information Model](https://developer.dcsa.org/documentation/information_models). This API specification does not define the allowable updates and their timing in accordance with the established business rules. **All use cases mentioned in this API specification refer to use cases defined in [DCSA Interface Standard for the Bill of Lading 3.0](https://dcsa.org/standards/bill-of-lading/documentation-bill-of-lading-3)**.
 
-    All other documents related to the Electronic Bill of Lading publication can be found [here](https://dcsa.org/standards/ebill-of-lading/)
+    All other documents related to the electronic Bill of Lading (referred to as `eBL`) publication can be found [here](https://dcsa.org/standards/ebill-of-lading/)
 
-    ### EBL (Implemented by provider)
+    ### eBL (Implemented by provider)
 
     It is possible to use the eBL API as a standalone API. In that case use one of the poll endPoints:
 
@@ -1233,7 +1233,7 @@ paths:
                     shippedOnBoardDate: '2023-12-20'
                     termsAndConditions: |
                       You agree that this transport document exist is name only for the sake of
-                      testing your conformance with the DCSA EBL API. This transport document is NOT backed
+                      testing your conformance with the DCSA eBL API. This transport document is NOT backed
                       by a real shipment with ANY carrier and NONE of the requested services will be
                       carried out in real life.
 
@@ -1342,7 +1342,7 @@ paths:
                     shippedOnBoardDate: '2023-12-20'
                     termsAndConditions: |
                       You agree that this transport document exist is name only for the sake of
-                      testing your conformance with the DCSA EBL API. This transport document is NOT backed
+                      testing your conformance with the DCSA eBL API. This transport document is NOT backed
                       by a real shipment with ANY carrier and NONE of the requested services will be
                       carried out in real life.
 
@@ -1455,7 +1455,7 @@ paths:
                     shippedOnBoardDate: '2023-12-20'
                     termsAndConditions: |
                       You agree that this transport document exist is name only for the sake of
-                      testing your conformance with the DCSA EBL API. This transport document is NOT backed
+                      testing your conformance with the DCSA eBL API. This transport document is NOT backed
                       by a real shipment with ANY carrier and NONE of the requested services will be
                       carried out in real life.
 
@@ -1889,7 +1889,7 @@ paths:
       description: |
         Creates a new [`Shipping Instructions Notification`](#/ShippingInstructionsNotification). This endPoint is called whenever a `Shipping Instructions` that a consumer has subscribed to changes state or is updated.
 
-        **This endPoint is to be implemented by a consumer of the EBL API in order to receive Notifications**
+        **This endPoint is to be implemented by a consumer of the eBL API in order to receive Notifications**
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
       requestBody:
@@ -2214,7 +2214,7 @@ paths:
       description: |
         Creates a new [`Transport Document Notification`](#/TransportDocumentNotification). This endPoint is called whenever a `Transport Document` that a cosumer has subscribed to changes state or is updated.
 
-        **This endPoint is to be implemented by a consumer of the EBL API in order to receive Notifications**
+        **This endPoint is to be implemented by a consumer of the eBL API in order to receive Notifications**
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
       requestBody:
@@ -2269,7 +2269,7 @@ paths:
                       shippedOnBoardDate: '2023-12-20'
                       termsAndConditions: |
                         You agree that this transport document exist is name only for the sake of
-                        testing your conformance with the DCSA EBL API. This transport document is NOT backed
+                        testing your conformance with the DCSA eBL API. This transport document is NOT backed
                         by a real shipment with ANY carrier and NONE of the requested services will be
                         carried out in real life.
 
@@ -2405,7 +2405,7 @@ paths:
                       shippedOnBoardDate: '2023-12-20'
                       termsAndConditions: |
                         You agree that this transport document exist is name only for the sake of
-                        testing your conformance with the DCSA EBL API. This transport document is NOT backed
+                        testing your conformance with the DCSA eBL API. This transport document is NOT backed
                         by a real shipment with ANY carrier and NONE of the requested services will be
                         carried out in real life.
 
@@ -4899,7 +4899,7 @@ components:
           pattern: ^\S+$
           maxLength: 4
           description: |
-            The EBL platform of the transaction party. 
+            The eBL platform of the transaction party. 
             The value **MUST** be one of:
             - `WAVE` (Wave)
             - `CARX` (CargoX)

--- a/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.0.yaml
@@ -6,11 +6,11 @@ info:
   version: 3.0.0
   title: DCSA eBL Issuance API
   description: |
-    <h1>DCSA OpenAPI specification for the issuance of an electronic Bill of Lading (eBL) via an eBL Solution Provider</h1>
+    <h1>DCSA OpenAPI specification for the issuance of an electronic Bill of Lading (referred to as `eBL`) via an eBL Solution Provider</h1>
 
-    This API is intended as an API between a carrier and a EBL Solution Platform.
+    This API is intended as an API between a carrier and a eBL Solution Platform.
 
-    The EBL Solution Provider is to implement
+    The eBL Solution Provider is to implement
 
         PUT /v3/ebl-issuance-requests
 
@@ -18,9 +18,9 @@ info:
 
         POST /v3/ebl-issuance-responses
 
-    for the EBL Solution Provider to call.
+    for the eBL Solution Provider to call.
 
-    When the document is to be surrendered, it should happen via a version of the [DCSA EBL Surrender](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_EBL_SUR/3.0.0) API.
+    When the document is to be surrendered, it should happen via a version of the [DCSA eBL Surrender](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_EBL_SUR/3.0.0) API.
 
     ### API Design & Implementation Principles
     This API follows the guidelines defined in version 2.1 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design)
@@ -40,9 +40,9 @@ info:
     url: 'https://dcsa.org'
     email: info@dcsa.org
 tags:
-  - name: Issuance EBL
+  - name: Issuance eBL
     description: |
-      Issuance EBL **implemented** by EBL Solution Platform
+      Issuance eBL **implemented** by eBL Solution Platform
   - name: Issuance Response
     description: |
       Issuance Response **implemented** by carrier
@@ -50,13 +50,13 @@ paths:
   /v3/ebl-issuance-requests:
     put:
       tags:
-        - Issuance EBL
+        - Issuance eBL
       operationId: put-ebl-issuance-requests
-      summary: Request issuance of an EBL
+      summary: Request issuance of an eBL
       description: |
-        Submit a transport document (EBL) for issuance
+        Submit a transport document (eBL) for issuance
 
-        **This endPoint is to be implemented by an EBL Solution Provider for the carrier to call**
+        **This endPoint is to be implemented by an eBL Solution Provider for the carrier to call**
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
       requestBody:
@@ -78,7 +78,7 @@ paths:
           description: |
             An Issuance Request is made with a `Transport Document Reference` (TDR), that was used previously to request the issuance of a `Transport Document` (TD). The document is either already issued or an TD with the same TDR.
 
-            The eBL platform will inform the carrier when the carrier needs to act on this document again. If the issuance is pending, then the carrier will be notified via the DCSA_EBL_ISS_RSP API once the issuance process completes. If the issuance has already succeeded, the eBL platform will notify the carrier when there is a surrender request via the DCSA_EBL_SUR API.
+            The eBL platform will inform the carrier when the carrier needs to act on this document again. If the issuance is pending, then the carrier will be notified via the `/v3/ebl-issuance-responses` endPoint once the issuance process completes. If the issuance has already succeeded, the eBL platform will notify the carrier when there is a surrender request via the DCSA_EBL_SUR API.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
@@ -124,7 +124,7 @@ paths:
       description: |
         Submit a response to a carrier issuance request.
 
-        **This endPoint is to be implemented by a carrier for the EBL Solution Provider to call**
+        **This endPoint is to be implemented by a carrier for the eBL Solution Provider to call**
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
       requestBody:
@@ -402,7 +402,7 @@ components:
           pattern: ^\S+$
           maxLength: 4
           description: |
-            The EBL platform of the transaction party. 
+            The eBL platform of the transaction party. 
             The value **MUST** be one of:
             - `WAVE` (Wave)
             - `CARX` (CargoX)
@@ -3235,7 +3235,7 @@ components:
         issuanceResponseCode:
           type: string
           description: |
-            The platforms verdict on the issuance of the EBL  identified by the `transportDocumentReference`
+            The platforms verdict on the issuance of the eBL  identified by the `transportDocumentReference`
 
             Options are:
               - `ISSU`: The document was successfully `ISSU` and successfully delivered to the initial possessor.

--- a/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
+++ b/ebl/v3/surrender/EBL_SUR_v3.0.0.yaml
@@ -6,26 +6,26 @@ info:
   version: 3.0.0
   title: DCSA eBL Surrender API
   description: |
-    <h1>DCSA OpenAPI specification for the surrender of an electronic Bill of Lading (eBL) via an eBL Solution Provider for amendment (incl. switch to paper), and delivery</h1>
+    <h1>DCSA OpenAPI specification for the surrender of an electronic Bill of Lading (referred to as `eBL`) via an eBL Solution Provider for amendment (incl. switch to paper), and delivery</h1>
 
-    This API is intended as an API between a carrier and an EBL Solution Platform.
+    This API is intended as an API between a carrier and an eBL Solution Platform.
 
-    The EBL Solution Platform will submit surrender requests to the carrier, via
+    The eBL Solution Platform will submit surrender requests to the carrier, via
     
         POST /v3/ebl-surrender-requests
     
-    which will be processed asynchronously. The EBL Solution Platform submitting the surrender request to the carrier must be the same EBL Solution Platform from which the eBL was issued. Responses to the surrender requests will be submitted by the carrier via 
+    which will be processed asynchronously. The eBL Solution Platform submitting the surrender request to the carrier must be the same eBL Solution Platform from which the eBL was issued. Responses to the surrender requests will be submitted by the carrier via 
     
         POST /v3/ebl-surrender-responses
 
     When the platform submits a surrender request, the platform guarantees *all* of the following:
 
-    1) The surrender request was submitted by the sole possessor of the EBL.
+    1) The surrender request was submitted by the sole possessor of the eBL.
     2) Depending on the eBL type:
        * For non-negotiable ("straight") eBLs, the surrender request was submitted by either the original shipper OR the consignee.
        * For negotiable eBLs with a named titleholder, the surrender request was submitted by the named titleholder.
        * For negotiable eBLs without a named titleholder / blank eBLs, possession is sufficient for the entity surrendering the eBL.
-    3) The carrier holds possession of the EBL with this surrender request  until it responds to this surrender request.
+    3) The carrier holds possession of the eBL with this surrender request  until it responds to this surrender request.
 
     Please see the [Surrender Request](#/surrenderRequestDetails) for details on what data the platform will provide.
 
@@ -51,7 +51,7 @@ tags:
       The Surrender Requests **implemented** by carrier
   - name: Surrender Request responses
     description: |
-      The Surrender Request responses **implemented** by the EBL Solution Platform
+      The Surrender Request responses **implemented** by the eBL Solution Platform
 paths:
   /v3/ebl-surrender-requests:
     post:
@@ -61,7 +61,7 @@ paths:
       summary: |
         Creates a Surrender Request
       description: |
-        The EBL Solution Platform uses this endpoint to submit a surrender request.
+        The eBL Solution Platform uses this endpoint to submit a surrender request.
 
         The carrier's answer to the surrender request will be returned via a callback response (see the `Callbacks` tab)
       parameters:
@@ -95,7 +95,7 @@ paths:
         - Surrender Request responses
       operationId: post-ebl-surrender-responses
       description: |
-        The carrier uses this endpoint to inform the EBL Solution Platform about the verdict for a given surrender request.
+        The carrier uses this endpoint to inform the eBL Solution Platform about the verdict for a given surrender request.
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
       requestBody:
@@ -158,7 +158,7 @@ components:
           pattern: ^\S+$
           maxLength: 4
           description: |
-            The EBL platform of the transaction party. The value **MUST** be one of:
+            The eBL platform of the transaction party. The value **MUST** be one of:
             - `WAVE` (Wave)
             - `CARX` (CargoX)
             - `ESSD` (EssDOCS)
@@ -234,12 +234,12 @@ components:
 
         The platform guarantees *all* of the following:
 
-          1) The surrender request was submitted by the sole possessor of the EBL.
+          1) The surrender request was submitted by the sole possessor of the eBL.
           2) Depending on the eBL type:
            * For non-negotiable ("straight") eBLs, the surrender request was submitted by either the original shipper OR the consignee.
            * For negotiable eBLs with a named titleholder, the surrender request was submitted by the named titleholder.
            * For negotiable eBLs without a named titleholder / blank eBLs, possession is sufficient for the entity surrendering the eBL.
-          3) The carrier holds possession of the EBL with this surrender request  until it responds to this surrender request.
+          3) The carrier holds possession of the eBL with this surrender request  until it responds to this surrender request.
       properties:
         surrenderRequestReference:
           type: string
@@ -532,7 +532,7 @@ components:
           example: Z12345
           pattern: ^\S(?:.*\S)?$
           description: |
-            The surrender request provided by the EBL solution in the surrender request.
+            The surrender request provided by the eBL solution in the surrender request.
         action:
           type: string
           description: |
@@ -542,7 +542,7 @@ components:
 
             When the carrier accepts the surrender (`SURR`), the platform will inform the party that submitted the surrender request that the surrender has been accepted.  If the surrender is due to an amendment, the carrier will follow up with issuing the amended document to the party that submitted the surrender. The carrier will immediately become the possessor of the bill and can now void it.
 
-            When the carrier rejects the surrender (`SREJ`), the EBL is returned to the party that submitted the surrender request.
+            When the carrier rejects the surrender (`SREJ`), the eBL is returned to the party that submitted the surrender request.
           enum:
             - SURR
             - SREJ

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -627,7 +627,7 @@ components:
           pattern: ^\S+$
           maxLength: 4
           description: |
-            The EBL platform of the transaction party. 
+            The eBL platform of the transaction party. 
             The value **MUST** be one of:
             - `WAVE` (Wave)
             - `CARX` (CargoX)
@@ -887,7 +887,7 @@ components:
              
              The `RESD` `action` is used when the party wants to request the delivery of the goods. If the request is accepted (for details see `SACC` `action`), the carrier and the party submitting the surrender request will negotiate how the goods will be delivered (e.g. via DCSA shipment release API).
              
-             The `RESA` `action` is used when the party wants to surrender the eBL document, so that the carrier can issue an amended eBL document. If the request is accepted (for details see `SACC` `action` response), the alignment on the exact change(s) that need to be made to the eBL document is done outside of the PINT API (e.g. via the DCSA EBL API). If the request is accepted, the existing eBL document is voided along with its envelope transfer chain, and the amended eBL document must be reissued with a new envelope transfer chain (for details see the `ISSU` `action` type description paragraph above). The `RESA` `action` is also used for switch to paper as the DCSA process flow for switching to paper is part of the amendment process (e.g. to note how many originals and copies with and without charges should be issued).
+             The `RESA` `action` is used when the party wants to surrender the eBL document, so that the carrier can issue an amended eBL document. If the request is accepted (for details see `SACC` `action` response), the alignment on the exact change(s) that need to be made to the eBL document is done outside of the PINT API (e.g. via the DCSA eBL API). If the request is accepted, the existing eBL document is voided along with its envelope transfer chain, and the amended eBL document must be reissued with a new envelope transfer chain (for details see the `ISSU` `action` type description paragraph above). The `RESA` `action` is also used for switch to paper as the DCSA process flow for switching to paper is part of the amendment process (e.g. to note how many originals and copies with and without charges should be issued).
 
             If a surrender request (`RESD` `action` or `RESA` `action`) is not addressed to the carrier that issued the eBL document or to their legal representative, then the receiving platform should reject the envelope transfer with the [`EnvelopeTransferFinishedResponse`](#/EnvelopeTransferFinishedResponse) containing `BENV` [`responseCode`](#/EnvelopeTransferFinishedResponse).
 
@@ -951,7 +951,7 @@ components:
           pattern: ^\S+$
           maxLength: 4
           description: |
-            The EBL platform of the transaction party. 
+            The eBL platform of the transaction party. 
             The value **MUST** be one of:
             - `WAVE` (Wave)
             - `CARX` (CargoX)


### PR DESCRIPTION
[SD-1736](https://dcsa.atlassian.net/browse/SD-1736): Align how eBL is referred to (don't use **E**BL)
Side fix: `DCSA_EBL_ISS_RSP API` was wrongly referred to --> change it to the `/v3/ebl-issuance-responses` endPoint

[SD-1736]: https://dcsa.atlassian.net/browse/SD-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ