### PR TITLE
SD-1779: Remove condition on IdentifyingCodes as it is mandatory

### DIFF
--- a/ebl/v3/EBL_v3.0.0.yaml
+++ b/ebl/v3/EBL_v3.0.0.yaml
@@ -4530,7 +4530,7 @@ components:
         
         **Condition:** Mandatory for non-negotiable BL (`isToOrder=false`)
 
-        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`. If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -4571,8 +4571,6 @@ components:
         identifyingCodes:
           type: array
           minItems: 1
-          description: |
-            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:
@@ -4747,7 +4745,7 @@ components:
         
         **Condition:** Can only be provided for negotiable BLs (`isToOrder=true`). If a negotiable BL does not have an `Endorsee`, the BL is said to be "blank endorsed". Note `Consignee` and `Endorsee` are mutually exclusive.
 
-        **Condition:** Either the `address` or a party `identifyingCode` must be provided in the `Shipping Instructions`. If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
+        **Condition:** If a `displayedAddress` is provided, it must be included in the `Transport Document` instead of the `address`.
       properties:
         partyName:
           type: string
@@ -4778,8 +4776,6 @@ components:
         identifyingCodes:
           type: array
           minItems: 1
-          description: |
-            **Condition:** Either the `address` or a party `identifyingCode` must be provided. 
           items:
             $ref: '#/components/schemas/IdentifyingCode'
         taxLegalReferences:


### PR DESCRIPTION
[SD-1779](https://dcsa.atlassian.net/browse/SD-1779): Remove wrong condition for `identifyingCodes` on `Consignee` and `Endorsee` (as both properties are required)

[SD-1779]: https://dcsa.atlassian.net/browse/SD-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ