### PR TITLE
SD-1825: Add `routingReference` to CS and BKG

### DIFF
--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -3018,7 +3018,7 @@ components:
           description: |
             The name of a service as specified by the carrier.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property is not needed.
           example: Great Lion Service
         carrierServiceCode:
           type: string
@@ -3027,7 +3027,7 @@ components:
           description: |
             The carrier specific code of the service for which the schedule details are published.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property is not needed.
           example: FE1
         universalServiceReference:
           type: string
@@ -3045,7 +3045,7 @@ components:
           description: |
             The carrier specific identifier of the export Voyage.
 
-            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided.
+            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property is not needed.
         universalExportVoyageReference:
           type: string
           pattern: ^\d{2}[0-9A-Z]{2}[NEWSR]$
@@ -3143,7 +3143,7 @@ components:
           description: |
             The date when the shipment is expected to be loaded on board a vessel as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3151,7 +3151,7 @@ components:
           description: |
             The start date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryEndDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryEndDate:
           type: string
@@ -3159,7 +3159,7 @@ components:
           description: |
             The end date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryStartDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-19'
         transportDocumentTypeCode:
           type: string
@@ -3346,7 +3346,7 @@ components:
           description: |
             The name of a service as specified by the carrier.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property is not needed.
           example: Great Lion Service
         carrierServiceCode:
           type: string
@@ -3355,7 +3355,7 @@ components:
           description: |
             The carrier specific code of the service for which the schedule details are published.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property is not needed.
           example: FE1
         universalServiceReference:
           type: string
@@ -3373,7 +3373,7 @@ components:
           description: |
             The carrier specific identifier of the export Voyage.
 
-            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided.
+            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property is not needed.
         universalExportVoyageReference:
           type: string
           pattern: ^\d{2}[0-9A-Z]{2}[NEWSR]$
@@ -3470,7 +3470,7 @@ components:
           description: |
             The date when the shipment is expected to be loaded on board a vessel as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3478,7 +3478,7 @@ components:
           description: |
             The start date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryEndDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryEndDate:
           type: string
@@ -3486,7 +3486,7 @@ components:
           description: |
             The end date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryStartDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-19'
         transportDocumentTypeCode:
           type: string
@@ -3740,7 +3740,7 @@ components:
           description: |
             The name of a service as specified by the carrier.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property is not needed.
           example: Great Lion Service
         carrierServiceCode:
           type: string
@@ -3749,7 +3749,7 @@ components:
           description: |
             The carrier specific code of the service for which the schedule details are published.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property is not needed.
           example: FE1
         universalServiceReference:
           type: string
@@ -3767,7 +3767,7 @@ components:
           description: |
             The carrier specific identifier of the export Voyage.
 
-            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided.
+            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property is not needed.
         universalExportVoyageReference:
           type: string
           pattern: ^\d{2}[0-9A-Z]{2}[NEWSR]$
@@ -3864,7 +3864,7 @@ components:
           description: |
             The date when the shipment is expected to be loaded on board a vessel as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3872,7 +3872,7 @@ components:
           description: |
             The start date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryEndDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryEndDate:
           type: string
@@ -3880,7 +3880,7 @@ components:
           description: |
             The end date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryStartDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
           example: '2021-05-19'
         transportDocumentTypeCode:
           type: string
@@ -4859,6 +4859,8 @@ components:
       title: Shipment Location
       description: |
         Maps the relationship between `Shipment` and `Location`, e.g., the `Place of Receipt` and the `Place of Delivery` for a specific shipment. This is a reusable object between `Booking` and `Transport Document`
+
+        **Condition:** In case `routingReference` is provided - then `PRE` (Place of Receipt), `POL` (Port of Loading), `POD` (Port of Discharge) and `PDE` (Place of Delivery) mare not needed to be provided.
       properties:
         location:
           $ref: '#/components/schemas/Location'
@@ -6687,7 +6689,7 @@ components:
       description: |
         Vessels related to this booking request.
         
-        **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and `carrierServiceCode` or `carrierServiceName` are blank.
+        **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and `carrierServiceCode` or `carrierServiceName` are blank. If `routingReference` is provided - this object is not needed.
       required:
         - name
       properties:

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -31,6 +31,10 @@ info:
 
     **Note:** All `/v2/bookings` endPoints must be implemented by the provider.
 
+    ### Extensions
+    This API lists all the governed extensions and how they should be used.
+    - `DCSA_CS-routing_indicator` - an extension to be used in order to include the `routingReference` property to link this API to the Commercial Schedules API
+
     ### Notifications (Implemented by consumer)
     It is possible to have notifications pushed to you whenever the provider needs input and/or a state change. The format of the notification is defined by the [Booking Notification endPoint](#/BookingNotification).
 
@@ -4860,7 +4864,7 @@ components:
       description: |
         Maps the relationship between `Shipment` and `Location`, e.g., the `Place of Receipt` and the `Place of Delivery` for a specific shipment. This is a reusable object between `Booking` and `Transport Document`
 
-        **Condition:** In case `routingReference` is provided - then `PRE` (Place of Receipt), `POL` (Port of Loading), `POD` (Port of Discharge) and `PDE` (Place of Delivery) mare not needed to be provided.
+        **Condition:** In case `routingReference` is provided - then `PRE` (Place of Receipt), `POL` (Port of Loading), `POD` (Port of Discharge) and `PDE` (Place of Delivery) are not needed.
       properties:
         location:
           $ref: '#/components/schemas/Location'

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -3022,7 +3022,7 @@ components:
                 - `PDE` (Place of Delivery)
                 - `RTP` (Requested transshipment port)
             
-            **Condition:** Using this property is an extension to the official DCSA Booking 2.0.0 API. In order to use this property the following header attribute needs to be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
+            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
           example: Route123
         declaredValue:
           type: number
@@ -3350,7 +3350,7 @@ components:
                 - `PDE` (Place of Delivery)
                 - `RTP` (Requested transshipment port)
             
-            **Condition:** Using this property is an extension to the official DCSA Booking 2.0.0 API. In order to use this property the following header attribute needs to be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
+            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
           example: Route123
         declaredValue:
           type: number
@@ -3745,7 +3745,7 @@ components:
                 - `PDE` (Place of Delivery)
                 - `RTP` (Requested transshipment port)
             
-            **Condition:** Using this property is an extension to the official DCSA Booking 2.0.0 API. In order to use this property the following header attribute needs to be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
+            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
           example: Route123
         declaredValue:
           type: number

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -3069,7 +3069,7 @@ components:
         routingReference:
           type: string
           pattern: ^\S(?:.*\S)?$
-          maxLength: 100
+          maxLength: 5000
           description: |
             A reference to a predefined `route` specified in **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
               - `vessel` which includes:

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -72,7 +72,7 @@ paths:
       operationId: create-bookings
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
       description: |
         Creates a new booking request. This endPoint corresponds with **UseCase 1 - Submit booking request**.
 
@@ -563,7 +563,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
       description: |
         Updates the `Booking Request` with the `bookingReference`. The path can contain one of `carrierBookingRequestReference` or `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with one of
         - **UseCase 3 - Submit updated Booking request**
@@ -1166,7 +1166,7 @@ paths:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/amendedContent'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
       responses:
         '200':
           description: Request successful
@@ -1841,7 +1841,7 @@ paths:
         **This endPoint is to be implemented by a consumer of the Booking API in order to receive Notifications**
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
       requestBody:
         description: |
           The payload used to create a [`Booking Notification`](#/BookingNotification)

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -2305,7 +2305,7 @@ components:
         type: string
         example: 1.0.0
       description: |
-        This header returns the version of the `routingReference` returned if it has been enabled in the request.
+        This header returns the version of the `routingReference` if it has been enabled in the request.
   parameters:
     Api-Version-Major:
       in: header

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -3,7 +3,7 @@ servers:
   - description: SwaggerHub API Auto Mocking
     url: 'https://virtserver.swaggerhub.com/dcsaorg/DCSA_BKG/2.0.0'
 info:
-  version: 2.X
+  version: 2.0.0-Extensions
   title: DCSA Booking API
   description: |
     <h1>DCSA OpenAPI specification for the Booking process</h1>
@@ -3004,7 +3004,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 100
           description: |
-            A reference to a predefined `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+            A reference to a predefined `route` specified in **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
               - `vessel` which includes:
                 - `vesselName`
                 - `vesselIMONumber`
@@ -3021,6 +3021,8 @@ components:
                 - `POD` (Port of Discharge)
                 - `PDE` (Place of Delivery)
                 - `RTP` (Requested transshipment port)
+            
+            **Condition:** Using this property is an extension to the official DCSA Booking 2.0.0 API. In order to use this property the following header attribute needs to be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
           example: Route123
         declaredValue:
           type: number
@@ -3330,7 +3332,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 100
           description: |
-            A reference to a predefined `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+            A reference to a predefined `route` specified in **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
               - `vessel` which includes:
                 - `vesselName`
                 - `vesselIMONumber`
@@ -3347,6 +3349,8 @@ components:
                 - `POD` (Port of Discharge)
                 - `PDE` (Place of Delivery)
                 - `RTP` (Requested transshipment port)
+            
+            **Condition:** Using this property is an extension to the official DCSA Booking 2.0.0 API. In order to use this property the following header attribute needs to be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
           example: Route123
         declaredValue:
           type: number
@@ -3723,7 +3727,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 100
           description: |
-            A reference to a predefined `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+            A reference to a predefined `route` specified in **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
               - `vessel` which includes:
                 - `vesselName`
                 - `vesselIMONumber`
@@ -3740,6 +3744,8 @@ components:
                 - `POD` (Port of Discharge)
                 - `PDE` (Place of Delivery)
                 - `RTP` (Requested transshipment port)
+            
+            **Condition:** Using this property is an extension to the official DCSA Booking 2.0.0 API. In order to use this property the following header attribute needs to be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
           example: Route123
         declaredValue:
           type: number

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -1581,7 +1581,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
       requestBody:
         content:
           application/json:
@@ -1618,8 +1617,6 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               examples:
@@ -1647,8 +1644,6 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1692,8 +1687,6 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1745,8 +1738,6 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1778,8 +1769,6 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1811,8 +1800,6 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -3004,7 +3004,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 100
           description: |
-            A reference to a predifned `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+            A reference to a predefined `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
               - `vessel` which includes:
                 - `vesselName`
                 - `vesselIMONumber`
@@ -3330,7 +3330,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 100
           description: |
-            A reference to a predifned `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+            A reference to a predefined `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
               - `vessel` which includes:
                 - `vesselName`
                 - `vesselIMONumber`
@@ -3723,7 +3723,7 @@ components:
           pattern: ^\S(?:.*\S)?$
           maxLength: 100
           description: |
-            A reference to a predifned `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+            A reference to a predefined `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
               - `vessel` which includes:
                 - `vesselName`
                 - `vesselIMONumber`

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -47,10 +47,10 @@ info:
     **Note:** This endPoint is to be implemented by the consumers of the `Booking API` in order to receive push events.
 
     ### API Design & Implementation Principles
-    This API follows the guidelines defined in version 2.1 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design)
+    This API follows the guidelines defined in version 2.0 of the API Design & Implementation Principles which can be found on the [DCSA Developer Portal](https://developer.dcsa.org/api_design)
 
     ### Changelog and GitHub
-    For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/bkg/v2#v200). Please [create a GitHub issue](https://github.com/dcsaorg/DCSA-OpenAPI/issues/new) if you have any questions/comments.
+    For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/bkg/v2#v200). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
 
     API specification issued by [DCSA.org](https://dcsa.org/).
   license:
@@ -2600,7 +2600,7 @@ components:
     #########################################
     BookingFullNotification:
       type: object
-      title: Booking
+      title: Booking Full Notification
       description: |
         This property contains the booking in case the subscriber is subscribing to the `Full State Transfer` of the Booking.
 
@@ -3105,7 +3105,7 @@ components:
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
 
-            **Condition:** Mandatory if `declaredValue` is provided
+            **Condition:** Mandatory if `declaredValue` is provided. If `declaredValue` is not provided, this field must be empty.
           example: DKK
         carrierCode:
           type: string
@@ -3436,7 +3436,7 @@ components:
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
 
-            **Condition:** Mandatory if `declaredValue` is provided
+            **Condition:** Mandatory if `declaredValue` is provided. If `declaredValue` is not provided, this field must be empty.
           example: DKK
         carrierCode:
           type: string
@@ -3589,7 +3589,7 @@ components:
 
     DocumentPartiesReq:
       type: object
-      title: Document Parties
+      title: Document Parties (Shipper)
       description: |
         All `Parties` with associated roles.
       properties:
@@ -3834,7 +3834,7 @@ components:
           description: |
             The currency used for the declared value, using the 3-character code defined by [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html).
 
-            **Condition:** Mandatory if `declaredValue` is provided
+            **Condition:** Mandatory if `declaredValue` is provided. If `declaredValue` is not provided, this field must be empty.
           example: DKK
         carrierCode:
           type: string
@@ -4165,7 +4165,7 @@ components:
             - `CEL` (Celsius)
             - `FAH` (Fahrenheit)
 
-            **Condition:** Mandatory to provide if `temperatureSetpoint` is provided
+            **Condition:** Mandatory if `temperatureSetpoint` is provided. If `temperatureSetpoint` is not provided, this field must be empty.
           enum:
             - CEL
             - FAH
@@ -4208,7 +4208,7 @@ components:
             - `MQH` (Cubic metre per hour)
             - `FQH` (Cubic foot per hour)
 
-            **Condition:** Mandatory to provide if `airExchange` is provided
+            **Condition:** Mandatory if `airExchange` is provided. If `airExchange` is not provided, this field must be empty.
           enum:
             - MQH
             - FQH

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -2999,6 +2999,29 @@ components:
             - `2 alphanumeric characters` for the sequence number of the voyage
             - `1 character` for the direction/haul (`N`orth, `E`ast, `W`est, `S`outh or `R`oundtrip).
           example: 2103N
+        routingReference:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            A reference to a predifned `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+              - `vessel` which includes:
+                - `vesselName`
+                - `vesselIMONumber`
+              - `carrierServiceName`
+              - `carrierServiceCode`
+              - `universalServiceReference`
+              - `carrierExportVoyageNumber`
+              - `universalExportVoyageReference`
+              - `expectedDepartureDate`
+              - `expectedArrivalAtPlaceOfDeliveryStartDate` or `expectedArrivalAtPlaceOfDeliveryEndDate`
+              - the following `locationTypeCode` in `shipmentLocations`:
+                - `PRE` (Place of Receipt)
+                - `POL` (Port of Loading)
+                - `POD` (Port of Discharge)
+                - `PDE` (Place of Delivery)
+                - `RTP` (Requested transshipment port)
+          example: Route123
         declaredValue:
           type: number
           format: float
@@ -3302,6 +3325,29 @@ components:
             - `2 alphanumeric characters` for the sequence number of the voyage
             - `1 character` for the direction/haul (`N`orth, `E`ast, `W`est, `S`outh or `R`oundtrip).
           example: 2103N
+        routingReference:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            A reference to a predifned `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+              - `vessel` which includes:
+                - `vesselName`
+                - `vesselIMONumber`
+              - `carrierServiceName`
+              - `carrierServiceCode`
+              - `universalServiceReference`
+              - `carrierExportVoyageNumber`
+              - `universalExportVoyageReference`
+              - `expectedDepartureDate`
+              - `expectedArrivalAtPlaceOfDeliveryStartDate` or `expectedArrivalAtPlaceOfDeliveryEndDate`
+              - the following `locationTypeCode` in `shipmentLocations`:
+                - `PRE` (Place of Receipt)
+                - `POL` (Port of Loading)
+                - `POD` (Port of Discharge)
+                - `PDE` (Place of Delivery)
+                - `RTP` (Requested transshipment port)
+          example: Route123
         declaredValue:
           type: number
           format: float
@@ -3672,6 +3718,29 @@ components:
             - `2 alphanumeric characters` for the sequence number of the voyage
             - `1 character` for the direction/haul (`N`orth, `E`ast, `W`est, `S`outh or `R`oundtrip).
           example: 2103N
+        routingReference:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            A reference to a predifned `route` specified in the **Commercial Schedules - Point to point**. When specifying this property - it is not needed to specify the following properties:
+              - `vessel` which includes:
+                - `vesselName`
+                - `vesselIMONumber`
+              - `carrierServiceName`
+              - `carrierServiceCode`
+              - `universalServiceReference`
+              - `carrierExportVoyageNumber`
+              - `universalExportVoyageReference`
+              - `expectedDepartureDate`
+              - `expectedArrivalAtPlaceOfDeliveryStartDate` or `expectedArrivalAtPlaceOfDeliveryEndDate`
+              - the following `locationTypeCode` in `shipmentLocations`:
+                - `PRE` (Place of Receipt)
+                - `POL` (Port of Loading)
+                - `POD` (Port of Discharge)
+                - `PDE` (Place of Delivery)
+                - `RTP` (Requested transshipment port)
+          example: Route123
         declaredValue:
           type: number
           format: float

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -72,6 +72,7 @@ paths:
       operationId: create-bookings
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
       description: |
         Creates a new booking request. This endPoint corresponds with **UseCase 1 - Submit booking request**.
 
@@ -433,6 +434,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -451,6 +454,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -484,6 +489,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -515,6 +522,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -554,6 +563,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
       description: |
         Updates the `Booking Request` with the `bookingReference`. The path can contain one of `carrierBookingRequestReference` or `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with one of
         - **UseCase 3 - Submit updated Booking request**
@@ -942,6 +952,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               examples:
@@ -957,6 +969,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -990,6 +1004,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1022,6 +1038,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1055,6 +1073,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1086,6 +1106,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1144,12 +1166,15 @@ paths:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/amendedContent'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
       responses:
         '200':
           description: Request successful
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1343,6 +1368,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
         '404':
           description: |
             In case the consumer is requesting the `Amended Booking` by calling:
@@ -1360,6 +1387,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1411,6 +1440,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1444,6 +1475,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1475,6 +1508,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1546,6 +1581,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
       requestBody:
         content:
           application/json:
@@ -1582,6 +1618,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               examples:
@@ -1609,6 +1647,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1652,6 +1692,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1703,6 +1745,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1734,6 +1778,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1765,6 +1811,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -1806,6 +1854,7 @@ paths:
         **This endPoint is to be implemented by a consumer of the Booking API in order to receive Notifications**
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/headers/DCSA_CS-routing_indicator'
       requestBody:
         description: |
           The payload used to create a [`Booking Notification`](#/BookingNotification)
@@ -2145,12 +2194,16 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
         '400':
           description: |
             In case the `Notification` does not schema validate a `400` (Bad Request) is returned
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -2184,6 +2237,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -2215,6 +2270,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            DCSA_CS-routing_indicator:
+              $ref: '#/components/headers/DCSA_CS-routing_indicator'
           content:
             application/json:
               schema:
@@ -2252,6 +2309,12 @@ components:
         example: 2.0.0
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
+    DCSA_CS-routing_indicator:
+      schema:
+        type: string
+        example: 1.0.0
+      description: |
+        Indicator for the `routingReference` to be used in this endPoint.
   parameters:
     Api-Version-Major:
       in: header
@@ -2262,6 +2325,15 @@ components:
         example: '2'
       description: |
         An API-Version header **MAY** be added to the request (optional); if added it **MUST** only contain **MAJOR** version. API-Version header **MUST** be aligned with the URI version.
+    DCSA_CS-routing_indicator:
+      in: header
+      name: DCSA_CS-routing_indicator
+      required: false
+      schema:
+        type: string
+        example: '1.0.0'
+      description: |
+        Indicator for the `routingReference` to be used in this endPoint.
 
     #############
     # Path params
@@ -3020,9 +3092,8 @@ components:
                 - `POL` (Port of Loading)
                 - `POD` (Port of Discharge)
                 - `PDE` (Place of Delivery)
-                - `RTP` (Requested transshipment port)
             
-            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
+            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `1.0.0`
           example: Route123
         declaredValue:
           type: number
@@ -3348,9 +3419,8 @@ components:
                 - `POL` (Port of Loading)
                 - `POD` (Port of Discharge)
                 - `PDE` (Place of Delivery)
-                - `RTP` (Requested transshipment port)
             
-            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
+            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `1.0.0`
           example: Route123
         declaredValue:
           type: number
@@ -3743,9 +3813,8 @@ components:
                 - `POL` (Port of Loading)
                 - `POD` (Port of Discharge)
                 - `PDE` (Place of Delivery)
-                - `RTP` (Requested transshipment port)
             
-            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `v1.0.0`
+            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `1.0.0`
           example: Route123
         declaredValue:
           type: number

--- a/bkg/v2/BKG_v2.X.yaml
+++ b/bkg/v2/BKG_v2.X.yaml
@@ -33,7 +33,7 @@ info:
 
     ### Extensions
     This API lists all the governed extensions and how they should be used.
-    - `DCSA_CS-routing_indicator` - an extension to be used in order to include the `routingReference` property to link this API to the Commercial Schedules API
+    - `RoutingReference-DCSA_BKG-Extension-Version` - an extension to be used in order to include the `routingReference` property to link this API to the Commercial Schedules API
 
     ### Notifications (Implemented by consumer)
     It is possible to have notifications pushed to you whenever the provider needs input and/or a state change. The format of the notification is defined by the [Booking Notification endPoint](#/BookingNotification).
@@ -76,7 +76,7 @@ paths:
       operationId: create-bookings
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/RoutingReference-DCSA_BKG-Extension-Version-Major'
       description: |
         Creates a new booking request. This endPoint corresponds with **UseCase 1 - Submit booking request**.
 
@@ -438,8 +438,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -458,8 +458,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -493,8 +493,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -526,8 +526,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -567,7 +567,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/RoutingReference-DCSA_BKG-Extension-Version-Major'
       description: |
         Updates the `Booking Request` with the `bookingReference`. The path can contain one of `carrierBookingRequestReference` or `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with one of
         - **UseCase 3 - Submit updated Booking request**
@@ -956,8 +956,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               examples:
@@ -973,8 +973,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1008,8 +1008,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1042,8 +1042,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1077,8 +1077,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1110,8 +1110,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1170,15 +1170,15 @@ paths:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/amendedContent'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/RoutingReference-DCSA_BKG-Extension-Version-Major'
       responses:
         '200':
           description: Request successful
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1372,8 +1372,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
         '404':
           description: |
             In case the consumer is requesting the `Amended Booking` by calling:
@@ -1391,8 +1391,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1444,8 +1444,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1479,8 +1479,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1512,8 +1512,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -1845,7 +1845,7 @@ paths:
         **This endPoint is to be implemented by a consumer of the Booking API in order to receive Notifications**
       parameters:
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/DCSA_CS-routing_indicator'
+        - $ref: '#/components/parameters/RoutingReference-DCSA_BKG-Extension-Version-Major'
       requestBody:
         description: |
           The payload used to create a [`Booking Notification`](#/BookingNotification)
@@ -2185,16 +2185,16 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
         '400':
           description: |
             In case the `Notification` does not schema validate a `400` (Bad Request) is returned
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -2228,8 +2228,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -2261,8 +2261,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
-            DCSA_CS-routing_indicator:
-              $ref: '#/components/headers/DCSA_CS-routing_indicator'
+            RoutingReference-DCSA_BKG-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_BKG-Extension-Version'
           content:
             application/json:
               schema:
@@ -2300,12 +2300,12 @@ components:
         example: 2.0.0
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
-    DCSA_CS-routing_indicator:
+    RoutingReference-DCSA_BKG-Extension-Version:
       schema:
         type: string
         example: 1.0.0
       description: |
-        Indicator for the `routingReference` to be used in this endPoint.
+        This header returns the version of the `routingReference` returned if it has been enabled in the request.
   parameters:
     Api-Version-Major:
       in: header
@@ -2316,15 +2316,15 @@ components:
         example: '2'
       description: |
         An API-Version header **MAY** be added to the request (optional); if added it **MUST** only contain **MAJOR** version. API-Version header **MUST** be aligned with the URI version.
-    DCSA_CS-routing_indicator:
+    RoutingReference-DCSA_BKG-Extension-Version-Major:
       in: header
-      name: DCSA_CS-routing_indicator
+      name: RoutingReference-DCSA_BKG-Extension-Version
       required: false
+      description: |
+        This header enables the DCSA API extension that enables the use of the `routingReference` attribute.
       schema:
         type: string
-        example: '1.0.0'
-      description: |
-        Indicator for the `routingReference` to be used in this endPoint.
+        example: '1'
 
     #############
     # Path params
@@ -3022,7 +3022,7 @@ components:
           description: |
             The name of a service as specified by the carrier.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property MUST not be provided.
           example: Great Lion Service
         carrierServiceCode:
           type: string
@@ -3031,7 +3031,7 @@ components:
           description: |
             The carrier specific code of the service for which the schedule details are published.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property MUST not be provided.
           example: FE1
         universalServiceReference:
           type: string
@@ -3040,6 +3040,8 @@ components:
           maxLength: 8
           description: |
             A global unique service reference, as per DCSA standard, agreed by VSA partners for the service. The service reference must match the regular expression pattern: `SR\d{5}[A-Z]`. The letters `SR` followed by `5 digits`, followed by a checksum-character as a capital letter from `A to Z`.
+
+            **Condition:** If `routingReference` is provided - this property MUST not be provided.
           example: SR12345A
         carrierExportVoyageNumber:
           type: string
@@ -3049,7 +3051,7 @@ components:
           description: |
             The carrier specific identifier of the export Voyage.
 
-            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
         universalExportVoyageReference:
           type: string
           pattern: ^\d{2}[0-9A-Z]{2}[NEWSR]$
@@ -3061,6 +3063,8 @@ components:
             - `2 digits` for the year
             - `2 alphanumeric characters` for the sequence number of the voyage
             - `1 character` for the direction/haul (`N`orth, `E`ast, `W`est, `S`outh or `R`oundtrip).
+
+            **Condition:** If `routingReference` is provided - this property MUST not be provided.
           example: 2103N
         routingReference:
           type: string
@@ -3084,7 +3088,7 @@ components:
                 - `POD` (Port of Discharge)
                 - `PDE` (Place of Delivery)
             
-            **Condition:** Using this property is an extension to the official **DCSA Booking v2.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_CS-routing_indicator` with a value of `1.0.0`
+            **Condition:** This attribute is part of the `RoutingReference` DCSA API extension, which must be explicitly enabled when used by setting in the API request the HTTP header name and value `RoutingReference-DCSA_BKG-Extension-Version: 1`. The API response will then contain the HTTP header name and value `RoutingReference-DCSA_BKG-Extension-Version: 1.0.0`
           example: Route123
         declaredValue:
           type: number
@@ -3147,7 +3151,7 @@ components:
           description: |
             The date when the shipment is expected to be loaded on board a vessel as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3155,7 +3159,7 @@ components:
           description: |
             The start date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryEndDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryEndDate:
           type: string
@@ -3163,7 +3167,7 @@ components:
           description: |
             The end date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryStartDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-19'
         transportDocumentTypeCode:
           type: string
@@ -3350,7 +3354,7 @@ components:
           description: |
             The name of a service as specified by the carrier.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property MUST not be provided.
           example: Great Lion Service
         carrierServiceCode:
           type: string
@@ -3359,7 +3363,7 @@ components:
           description: |
             The carrier specific code of the service for which the schedule details are published.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property MUST not be provided.
           example: FE1
         universalServiceReference:
           type: string
@@ -3368,6 +3372,8 @@ components:
           maxLength: 8
           description: |
             A global unique service reference, as per DCSA standard, agreed by VSA partners for the service. The service reference must match the regular expression pattern: `SR\d{5}[A-Z]`. The letters `SR` followed by `5 digits`, followed by a checksum-character as a capital letter from `A to Z`.
+
+            **Condition:** If `routingReference` is provided - this property MUST not be provided.
           example: SR12345A
         carrierExportVoyageNumber:
           type: string
@@ -3377,7 +3383,7 @@ components:
           description: |
             The carrier specific identifier of the export Voyage.
 
-            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
         universalExportVoyageReference:
           type: string
           pattern: ^\d{2}[0-9A-Z]{2}[NEWSR]$
@@ -3388,6 +3394,8 @@ components:
             - `2 digits` for the year
             - `2 alphanumeric characters` for the sequence number of the voyage
             - `1 character` for the direction/haul (`N`orth, `E`ast, `W`est, `S`outh or `R`oundtrip).
+
+            **Condition:** If `routingReference` is provided - this property MUST not be provided.
           example: 2103N
         routingReference:
           type: string
@@ -3474,7 +3482,7 @@ components:
           description: |
             The date when the shipment is expected to be loaded on board a vessel as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3482,7 +3490,7 @@ components:
           description: |
             The start date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryEndDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryEndDate:
           type: string
@@ -3490,7 +3498,7 @@ components:
           description: |
             The end date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryStartDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-19'
         transportDocumentTypeCode:
           type: string
@@ -3744,7 +3752,7 @@ components:
           description: |
             The name of a service as specified by the carrier.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceCode` are blank. If `routingReference` is provided - this property MUST not be provided.
           example: Great Lion Service
         carrierServiceCode:
           type: string
@@ -3753,7 +3761,7 @@ components:
           description: |
             The carrier specific code of the service for which the schedule details are published.
 
-            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and Vessel details or `carrierServiceName` are blank. If `routingReference` is provided - this property MUST not be provided.
           example: FE1
         universalServiceReference:
           type: string
@@ -3762,6 +3770,8 @@ components:
           minLength: 8
           description: |
             A global unique service reference, as per DCSA standard, agreed by VSA partners for the service. The service reference must match the regular expression pattern: `SR\d{5}[A-Z]`. The letters `SR` followed by `5 digits`, followed by a checksum-character as a capital letter from `A to Z`.
+
+            **Condition:** If `routingReference` is provided - this property MUST not be provided.
           example: SR12345A
         carrierExportVoyageNumber:
           type: string
@@ -3771,7 +3781,7 @@ components:
           description: |
             The carrier specific identifier of the export Voyage.
 
-            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if `expectedDepartureDate` or `expectedArrivalAtPlaceOfDeliveryStartDate` and `expectedArrivalAtPlaceOfDeliveryEndDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
         universalExportVoyageReference:
           type: string
           pattern: ^\d{2}[0-9A-Z]{2}[NEWSR]$
@@ -3782,6 +3792,8 @@ components:
             - `2 digits` for the year
             - `2 alphanumeric characters` for the sequence number of the voyage
             - `1 character` for the direction/haul (`N`orth, `E`ast, `W`est, `S`outh or `R`oundtrip).
+
+            **Condition:** If `routingReference` is provided - this property MUST not be provided.
           example: 2103N
         routingReference:
           type: string
@@ -3868,7 +3880,7 @@ components:
           description: |
             The date when the shipment is expected to be loaded on board a vessel as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3876,7 +3888,7 @@ components:
           description: |
             The start date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryEndDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryEndDate:
           type: string
@@ -3884,7 +3896,7 @@ components:
           description: |
             The end date (provided as a range together with `expectedArrivalAtPlaceOfDeliveryStartDate`) for when the shipment is expected to arrive at `Place Of Delivery`.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property is not needed.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedDepartureDate` is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-19'
         transportDocumentTypeCode:
           type: string
@@ -4864,7 +4876,7 @@ components:
       description: |
         Maps the relationship between `Shipment` and `Location`, e.g., the `Place of Receipt` and the `Place of Delivery` for a specific shipment. This is a reusable object between `Booking` and `Transport Document`
 
-        **Condition:** In case `routingReference` is provided - then `PRE` (Place of Receipt), `POL` (Port of Loading), `POD` (Port of Discharge) and `PDE` (Place of Delivery) are not needed.
+        **Condition:** In case `routingReference` is provided - then `PRE` (Place of Receipt), `POL` (Port of Loading), `POD` (Port of Discharge) and `PDE` (Place of Delivery) MUST not be provided.
       properties:
         location:
           $ref: '#/components/schemas/Location'
@@ -6693,7 +6705,7 @@ components:
       description: |
         Vessels related to this booking request.
         
-        **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and `carrierServiceCode` or `carrierServiceName` are blank. If `routingReference` is provided - this object is not needed.
+        **Condition:** Mandatory if `carrierExportVoyageNumber` is provided and `carrierServiceCode` or `carrierServiceName` are blank. If `routingReference` is provided - this object MUST not be provided.
       required:
         - name
       properties:

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -812,6 +812,13 @@ components:
           minimum: 1
           example: 1
           description: Solution number, starting with 1. Used to group and identify similar or same routings in the response as per the carrier commercial definitions.
+        routingReference:
+          type: string
+          pattern: ^\S(?:.*\S)?$
+          maxLength: 100
+          description: |
+            A reference to be used when creating a **Booking** in the **Booking API**.
+          example: Route123
         transitTime:
           type: integer
           description: The estimated total time in days that it takes a shipment to move from place of receipt to place of delivery. Transit time includes stop-over time during transhipments and waiting time at connection points, if applicable, thus can vary between the same locations.

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -27,7 +27,7 @@ info:
 
     ### Extensions
     This API lists all the governed extensions and how they should be used.
-    - `DCSA_BKG-routing_indicator` - an extension to be used in order to include the `routingReference` property to be used in the Booking API for using Point-to-Point routes
+    - `RoutingReference-DCSA_CS-Extension-Version` - an extension to be used in order to include the `routingReference` property to be used in the Booking API for using Point-to-Point routes
 
     ### API Design & Implementation Principles
     This API follows the guidelines defined in version 2.0 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design).
@@ -59,17 +59,9 @@ paths:
                   $ref: '#/components/schemas/PointToPoint'
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned
-            DCSA_CS-routing_indicator:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                Indicator for the `routingReference` to be used in this endPoint.
+              $ref: '#/components/headers/API-Version'
+            RoutingReference-DCSA_CS-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_CS-Extension-Version'
             Next-Page-Cursor:
               schema:
                 type: string
@@ -85,17 +77,9 @@ paths:
           description: Bad Request
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
-            DCSA_CS-routing_indicator:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                Indicator for the `routingReference` to be used in this endPoint.
+              $ref: '#/components/headers/API-Version'
+            RoutingReference-DCSA_CS-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_CS-Extension-Version'
           content:
             application/json:
               schema:
@@ -119,17 +103,9 @@ paths:
           description: Internal Server Error
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
-            DCSA_CS-routing_indicator:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                Indicator for the `routingReference` to be used in this endPoint.
+              $ref: '#/components/headers/API-Version'
+            RoutingReference-DCSA_CS-Extension-Version:
+              $ref: '#/components/headers/RoutingReference-DCSA_CS-Extension-Version'
           content:
             application/json:
               schema:
@@ -271,7 +247,7 @@ paths:
           description: A server generated value to specify a specific point in a collection result, used for pagination.
           example: fE9mZnNldHw9MTAmbGltaXQ9MTA
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/DCSA_BKG-routing_indicator'
+        - $ref: '#/components/parameters/RoutingReference-DCSA_CS-Extension-Version-Major'
       description: |
         Provides the product offering of single or multiple estimated end-to-end route options for a shipment in the pre-booking phase. This includes point-to-point specification of all transport legs, estimated timings, estimated schedules and interdependencies between transport legs.
 
@@ -296,11 +272,7 @@ paths:
                   $ref: '#/components/schemas/PortSchedule'
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
+              $ref: '#/components/headers/API-Version'
             Next-Page-Cursor:
               schema:
                 type: string
@@ -316,11 +288,7 @@ paths:
           description: Bad Request
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
+              $ref: '#/components/headers/API-Version'
           content:
             application/json:
               schema:
@@ -344,11 +312,7 @@ paths:
           description: Internal Server Error
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
+              $ref: '#/components/headers/API-Version'
           content:
             application/json:
               schema:
@@ -434,11 +398,7 @@ paths:
                   $ref: '#/components/schemas/ServiceSchedule'
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
+              $ref: '#/components/headers/API-Version'
             Next-Page-Cursor:
               schema:
                 type: string
@@ -454,11 +414,7 @@ paths:
           description: Bad Request
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
+              $ref: '#/components/headers/API-Version'
           content:
             application/json:
               schema:
@@ -482,11 +438,7 @@ paths:
           description: Internal Server Error
           headers:
             API-Version:
-              schema:
-                type: string
-                example: 1.0.0
-              description: |
-                SemVer used to indicate the version of the contract (API version) returned.
+              $ref: '#/components/headers/API-Version'
           content:
             application/json:
               schema:
@@ -842,7 +794,7 @@ components:
           description: |
             A reference to be used when creating a **Booking** in the **Booking API**.
             
-            **Condition:** Using this property is an extension to the official **DCSA Commercial schedules v1.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_BKG-routing_indicator` with a value of `1.0.0`
+            **Condition:** This attribute is part of the `RoutingReference` DCSA API extension, which must be explicitly enabled when used by setting in the API request the HTTP header name and value `RoutingReference-DCSA_CS-Extension-Version: 1`. The API response will then contain the HTTP header name and value `RoutingReference-DCSA_CS-Extension-Version: 1.0.0`
           example: Route123
         transitTime:
           type: integer
@@ -1768,25 +1720,38 @@ components:
           description: A long description corresponding to the `errorCode` with additional information.
           example: Spaces not allowed in facility code
           maxLength: 5000
+  headers:
+    API-Version:
+      schema:
+        type: string
+        example: 1.0.0
+      description: |
+        SemVer used to indicate the version of the contract (API version) returned.
+    RoutingReference-DCSA_CS-Extension-Version:
+      schema:
+        type: string
+        example: 1.0.0
+      description: |
+        This header returns the version of the `routingReference` returned if it has been enabled in the request.
   parameters:
     Api-Version-Major:
       in: header
       name: API-Version
       required: false
+      description: |
+        An API-Version header **MAY** be added to the request (optional); if added it **MUST** only contain **MAJOR** version. API-Version header **MUST** be aligned with the URI version.
       schema:
         type: string
         example: '1'
-      description: |
-        An API-Version header **MAY** be added to the request (optional); if added it **MUST** only contain **MAJOR** version. API-Version header **MUST** be aligned with the URI version.
-    DCSA_BKG-routing_indicator:
+    RoutingReference-DCSA_CS-Extension-Version-Major:
       in: header
-      name: DCSA_BKG-routing_indicator
+      name: RoutingReference-DCSA_CS-Extension-Version
       required: false
+      description: |
+        This header enables the DCSA API extension that enables the use of the `routingReference` attribute.
       schema:
         type: string
-        example: '1.0.0'
-      description: |
-        Indicator for the `routingReference` to be used in this endPoint.
+        example: '1'
 tags:
   - name: Point To Point
     description: ' '

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: DCSA OpenAPI specification for Commercial Schedules
-  version: 1.X
+  version: 1.0.0-Extensions
   description: |
     API specification issued by [Digital Container Shipping Association (DCSA)](https://dcsa.org/).
 
@@ -818,6 +818,8 @@ components:
           maxLength: 100
           description: |
             A reference to be used when creating a **Booking** in the **Booking API**.
+            
+            **Condition:** Using this property is an extension to the official **DCSA Commercial schedules v1.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_BKG-routing_indicator` with a value of `v1.0.0`
           example: Route123
         transitTime:
           type: integer

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -1732,7 +1732,7 @@ components:
         type: string
         example: 1.0.0
       description: |
-        This header returns the version of the `routingReference` returned if it has been enabled in the request.
+        This header returns the version of the `routingReference` if it has been enabled in the request.
   parameters:
     Api-Version-Major:
       in: header

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -249,6 +249,7 @@ paths:
           description: A server generated value to specify a specific point in a collection result, used for pagination.
           example: fE9mZnNldHw9MTAmbGltaXQ9MTA
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/DCSA_BKG-routing_indicator'
       description: |
         Provides the product offering of single or multiple estimated end-to-end route options for a shipment in the pre-booking phase. This includes point-to-point specification of all transport legs, estimated timings, estimated schedules and interdependencies between transport legs.
 
@@ -378,6 +379,7 @@ paths:
           description: The date since when the estimated arrival and departures of vessels in a given port is required.
           required: true
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/DCSA_BKG-routing_indicator'
         - schema:
             type: integer
             format: int32
@@ -592,6 +594,7 @@ paths:
           name: cursor
           description: A server generated value to specify a specific point in a collection result, used for pagination.
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/DCSA_BKG-routing_indicator'
       description: |
         Provides, for a required specific service and/or voyage and/or vessel and/or location, the timetable of estimated departure and arrival times for each port call on the rotation of the vessel(s).
 
@@ -819,7 +822,7 @@ components:
           description: |
             A reference to be used when creating a **Booking** in the **Booking API**.
             
-            **Condition:** Using this property is an extension to the official **DCSA Commercial schedules v1.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_BKG-routing_indicator` with a value of `v1.0.0`
+            **Condition:** Using this property is an extension to the official **DCSA Commercial schedules v1.0.0** API. In order to use this property the following header attribute **MUST** be added to all requests (and responses): `DCSA_BKG-routing_indicator` with a value of `1.0.0`
           example: Route123
         transitTime:
           type: integer
@@ -1755,6 +1758,15 @@ components:
         example: '1'
       description: |
         An API-Version header **MAY** be added to the request (optional); if added it **MUST** only contain **MAJOR** version. API-Version header **MUST** be aligned with the URI version.
+    DCSA_BKG-routing_indicator:
+      in: header
+      name: DCSA_BKG-routing_indicator
+      required: false
+      schema:
+        type: string
+        example: '1.0.0'
+      description: |
+        Indicator for the `routingReference` to be used in this endPoint.
 tags:
   - name: Point To Point
     description: ' '

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -790,7 +790,7 @@ components:
         routingReference:
           type: string
           pattern: ^\S(?:.*\S)?$
-          maxLength: 100
+          maxLength: 5000
           description: |
             A reference to be used when creating a **Booking** in the **Booking API**.
             

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -60,6 +60,12 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned
+            DCSA_CS-routing_indicator:
+              schema:
+                type: string
+                example: 1.0.0
+              description: |
+                Indicator for the `routingReference` to be used in this endPoint.
             Next-Page-Cursor:
               schema:
                 type: string
@@ -80,6 +86,12 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
+            DCSA_CS-routing_indicator:
+              schema:
+                type: string
+                example: 1.0.0
+              description: |
+                Indicator for the `routingReference` to be used in this endPoint.
           content:
             application/json:
               schema:
@@ -108,6 +120,12 @@ paths:
                 example: 1.0.0
               description: |
                 SemVer used to indicate the version of the contract (API version) returned.
+            DCSA_CS-routing_indicator:
+              schema:
+                type: string
+                example: 1.0.0
+              description: |
+                Indicator for the `routingReference` to be used in this endPoint.
           content:
             application/json:
               schema:
@@ -379,7 +397,6 @@ paths:
           description: The date since when the estimated arrival and departures of vessels in a given port is required.
           required: true
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/DCSA_BKG-routing_indicator'
         - schema:
             type: integer
             format: int32
@@ -594,7 +611,6 @@ paths:
           name: cursor
           description: A server generated value to specify a specific point in a collection result, used for pagination.
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/DCSA_BKG-routing_indicator'
       description: |
         Provides, for a required specific service and/or voyage and/or vessel and/or location, the timetable of estimated departure and arrival times for each port call on the rotation of the vessel(s).
 

--- a/cs/v1/CS_v1.X.yaml
+++ b/cs/v1/CS_v1.X.yaml
@@ -25,6 +25,10 @@ info:
 
     Visit the [DCSA Website](https://dcsa.org/standards/commercial-schedules/) to find other documentation related to the standard publication (i.e. Interface Standard, Information Model).
 
+    ### Extensions
+    This API lists all the governed extensions and how they should be used.
+    - `DCSA_BKG-routing_indicator` - an extension to be used in order to include the `routingReference` property to be used in the Booking API for using Point-to-Point routes
+
     ### API Design & Implementation Principles
     This API follows the guidelines defined in version 2.0 of the API Design & Implementation Principles which can be found on the [DCSA Developer page](https://developer.dcsa.org/api_design).
 


### PR DESCRIPTION
### **User description**
[SD-1825](https://dcsa.atlassian.net/browse/SD-1825): Add the `routingReference` property to the **Point to Point** endPoint in `CS` and to POST, PUT and GET **Booking** endPoints
No header is added to endPoints that **DO NOT** contain the `routingReference` property.
Conditions have been added to properties that are not longer required to fill in case the `routingReference` property is provided.

Not part of this PR - I created the version to update on GitHub (for both BKG and CS it is a copy of the existing version with the version-property updated)

Added you @palatsangeetha for info...

[SD-1825]: https://dcsa.atlassian.net/browse/SD-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
enhancement


___

### **Description**
- Added a new `routingReference` property to both the Booking and Commercial Schedules APIs.
- The `routingReference` is a string with a specified pattern and a maximum length of 100 characters.
- Detailed descriptions and examples are provided for the `routingReference` property.
- The `routingReference` allows referencing a predefined route, simplifying the specification of other properties.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BKG_v2.X.yaml</strong><dd><code>Add `routingReference` property to Booking API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bkg/v2/BKG_v2.X.yaml

<li>Added <code>routingReference</code> property to the Booking API.<br> <li> Defined pattern and max length for <code>routingReference</code>.<br> <li> Provided detailed description and example for <code>routingReference</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/451/files#diff-2ede5be250ff16884889a3a209a0aa6144d34d6884b9d2d9a0f54142e69c5c21">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CS_v1.X.yaml</strong><dd><code>Introduce `routingReference` to Commercial Schedules API</code>&nbsp; </dd></summary>
<hr>

cs/v1/CS_v1.X.yaml

<li>Introduced <code>routingReference</code> property to Commercial Schedules API.<br> <li> Defined pattern and max length for <code>routingReference</code>.<br> <li> Added description and example for <code>routingReference</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/451/files#diff-9a9a1137bce35672e23fda208930ab43df05bf95983e9cb189314794c3928a2a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 🔍 To retrieve JIRA tickets as context to your PR description, please [register](https://qodo-merge-docs.qodo.ai/core-abilities/fetching_ticket_context/#jira-cloud) your organization.