### PR TITLE
SD-1863: Add extra portCallPhaseTypeCode condition

### DIFF
--- a/jit/v2/JIT_v2.0.0.yaml
+++ b/jit/v2/JIT_v2.0.0.yaml
@@ -1687,6 +1687,12 @@ components:
               - `TOWAGE` (Towage)
               - `MOORING` (Mooring)
               - `SEA_PASSAGE` (Sea Passage)
+
+            **Condition:** The property `portCallPhaseTypeCode` should **not** be sent with the following `portCallServiceType`:
+              - `ANCHORAGE` (Anchorage)
+              - `SLUDGE` (Sludge)
+              - `ANCHORAGE_OPERATIONS` (Anchorage Operations)
+              - `MOVES` (Moves)
           enum:
             - INBD
             - ALGS


### PR DESCRIPTION
### **User description**
[SD-1863](https://dcsa.atlassian.net/browse/SD-1863): Add extra condition to `portCallPhaseTypeCode`

[SD-1863]: https://dcsa.atlassian.net/browse/SD-1863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added a new condition in the JIT v2.0.0 specification file for the `portCallPhaseTypeCode`.
- Specified that `portCallPhaseTypeCode` should not be sent with certain `portCallServiceType` values, including `ANCHORAGE`, `SLUDGE`, `ANCHORAGE_OPERATIONS`, and `MOVES`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JIT_v2.0.0.yaml</strong><dd><code>Add condition for `portCallPhaseTypeCode` in JIT specification</code></dd></summary>
<hr>

jit/v2/JIT_v2.0.0.yaml

<li>Added a new condition for <code>portCallPhaseTypeCode</code>.<br> <li> Specified <code>portCallServiceType</code> values where <code>portCallPhaseTypeCode</code> <br>should not be sent.<br>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/458/files#diff-9515d70681d4860776aad1fa65c622e5b362021ad1f0c0ae1352067f49108299">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 🔍 To retrieve JIRA tickets as context to your PR description, please [register](https://qodo-merge-docs.qodo.ai/core-abilities/fetching_ticket_context/#jira-cloud) your organization.