### PR TITLE
CTR-270: Add CTR URL in the PINT transfer

### DIFF
--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -674,6 +674,27 @@ components:
             The field is conditional and must be provided in the first EnvelopeTransferChainEntry. The value must be signed by the carrier.
           # TODO: Update example
           example: eyJhbGciOiJSUzI1NiIsImtpZCI6IlVhRVdLNmt2ZkRITzNZT2NwUGl2M1RCT2JQTzk2SFZhR2U0czFhUUxBZU0ifQ.eyJkb2N1bWVudENoZWNrc3VtIjogIjhkYzk5ZDhhYzkyMjI0MGM1NWMwMzg0NWY0OWRlZjY0MTg3MTQ2NjUxYmFlNGY5YTYzMTMxMjc3Y2YwMGQ5ZGYiLCJlQkxWaXN1YWxpc2F0aW9uQnlDYXJyaWVyQ2hlY2tzdW0iOiAiNzZhN2QxNGM4M2Q3MjY4ZDY0M2FlNzM0NWM0NDhkZTYwNzAxZjk1NWQyNjRhNzQzZTY5MjhhMGI4MjY4YjI0ZiIsImlzc3VlVG9DaGVja3N1bSI6ICI3NmE3ZDE0YzgzZDcyNjhkNjQzYWU3MzQ1YzQ0OGRlNjA3MDFmOTU1ZDI2NGE3NDNlNjkyOGEwYjgyNjhiMjRmIn0.c4SJ9-61fE6RmeIuZ3EI-TSM0M6qXuOudtr3YhpDjqVMaYk_RYpaWYvw75ssTbjgGFKTBKCy5lpmOfb8Fq--Qu2k0MWbH6qdX5jTYwl0DX946RQg-hnmVTg9np3bmqVeKqKURyV-UUdG-KK_XCGzPZ-lZkeUlpMcIthQFs0pCODR9GPytv7ZXLPZFOmHM9fn3FD2yRqVhQzcs7HdcxMjCx6hkBW8Z-jW4qteVy2_E9uqjkKwlu_cQLoY83Z0mcjn0PZNQvKF10x7q1_Jjf_Su19UigTUu3pFMrzo4iPS_jcrFoIb3TSZNSzbgAwtujSBFOufPDyEmxlx1sH0ZowMvA
+        controlTrackingRegistry:
+          type: string
+          format: uri
+          maxLength: 1024
+          description: |
+            The URI of the Control Tracking Registry (CTR) used to protect the PINT transfers.
+
+            The URI must be the base URI of the CTR including the major version of the CTR API used.
+            This ensures that the receiver knows which major version of the CTR API is used for the
+            CTR protection.
+
+            The field is conditional and must be provided in the first EnvelopeTransferChainEntry if
+            it is provided. It must be omitted in all other EnvelopeTransferChainEntry objects.
+
+            When the attribute is provided in the first EnvelopeTransferChainEntry, then all transfers
+            must be recorded in the CTR in accordance with the DCSA CTR API. Transfers not recorded
+            in the CTR are invalid and must be rejected.
+
+            When the attribute is omitted in the first EnvelopeTransferChainEntry, the PINT transfers
+            are not protected by a CTR.
+          example: https://ctr.dcsa.org/v1
         transactions:
           type: array
           minItems: 1


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `controlTrackingRegistry` field to the schema.

- Defined the purpose and conditions for the `controlTrackingRegistry` field.

- Enhanced PINT transfer protection with Control Tracking Registry (CTR) integration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EBL_PINT_v3.0.0.yaml</strong><dd><code>Added `controlTrackingRegistry` field for CTR integration</code></dd></summary>
<hr>

pint/v3/EBL_PINT_v3.0.0.yaml

<li>Introduced a new <code>controlTrackingRegistry</code> field in the schema.<br> <li> Added detailed description and conditions for the field.<br> <li> Enhanced schema to support CTR-based PINT transfer protection.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/472/files#diff-fb06fe221b801b5d8ef10ae79e2c81a2b4e53a2245afdf4affa15e37703baf1c">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information