### PR TITLE
SD-1917: Make sure Next-Page-Cursor header is included in Collection results

### DIFF
--- a/jit/v2/JIT_v2.0.0.yaml
+++ b/jit/v2/JIT_v2.0.0.yaml
@@ -438,6 +438,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Next-Page-Cursor:
+              $ref: '#/components/headers/Next-Page-Cursor'
           content:
             application/json:
               schema:
@@ -760,6 +762,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Next-Page-Cursor:
+              $ref: '#/components/headers/Next-Page-Cursor'
           content:
             application/json:
               schema:
@@ -1049,6 +1053,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Next-Page-Cursor:
+              $ref: '#/components/headers/Next-Page-Cursor'
           content:
             application/json:
               schema:
@@ -1244,6 +1250,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Next-Page-Cursor:
+              $ref: '#/components/headers/Next-Page-Cursor'
           content:
             application/json:
               schema:
@@ -1435,6 +1443,8 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Next-Page-Cursor:
+              $ref: '#/components/headers/Next-Page-Cursor'
           content:
             application/json:
               schema:
@@ -1612,6 +1622,17 @@ components:
         example: 2.0.0
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
+    Next-Page-Cursor:
+      schema:
+        type: string
+        maxLength: 1024
+        example: fE9mZnNldHw9MTAmbGltaXQ9MTA
+      description: |
+        The Next-Page-Cursor header contains a cursor value that points to the next page of results in a paginated API response.
+        When an initial `GET` endpoint request includes the query parameter `limit=...` the API provider limits the number of items in the root array of the response to the specified limit. If the response would contain more items than the specified limit, the API provider includes only the first set of limit items and appends the following response header:
+        `Next-Page-Cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA`, a string that acts as a reference for the next page of results. The cursor value is used in subsequent requests to retrieve the next page by passing it as a query parameter: `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA`.
+
+        To retrieve the next page, the API consumer sends a `GET` request to the endpoint URL with only `?cursor=fE9mZnNldHw9MTAmbGltaXQ9MTA` as query parameter. The limit of items per page and any other query parameters may not be altered, therefore it may also not be specified when requesting subsequent pages. The API provider must ignore any query parameters passed along with a cursor, and should return a `400` error if any other query parameter is passed along with the `cursor`.
   parameters:
     Api-Version-Major:
       in: header


### PR DESCRIPTION
[SD-1917](https://dcsa.atlassian.net/browse/SD-1917): Adding `Next-Page-Cursor` header to all Collection results (all GET endPoints)

[SD-1917]: https://dcsa.atlassian.net/browse/SD-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ