### PR TITLE
SD-1989: Fix classifierCode query parameter bug

### DIFF
--- a/jit/v2/JIT_v2.0.0.yaml
+++ b/jit/v2/JIT_v2.0.0.yaml
@@ -2763,8 +2763,12 @@ components:
         The **Classifier Code** to filter by. Specifying this filter will ensure that the result set contains only objects where the `classifierCode` property is present and its value matches one of the values of the corresponding filter query parameter.
       schema:
         type: string
-        format: uuid
-        example: 0342254a-5927-4856-b9c9-aa12e7c00563
+        enum:
+          - ACT
+          - EST
+          - PLN
+          - REQ
+        example: 'ACT'
     
     #############
     # Path params


### PR DESCRIPTION
[SD-1989](https://dcsa.atlassian.net/browse/SD-1989): Fix `classifierCode` queryParameter bug

[SD-1989]: https://dcsa.atlassian.net/browse/SD-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ