### PR TITLE
SD-1824: Remove 'v2/' from the urls

### DIFF
--- a/jit/v2/JIT_v2.0.0.yaml
+++ b/jit/v2/JIT_v2.0.0.yaml
@@ -45,15 +45,15 @@ info:
     To request a **Port Call Service** do the following:
      - Create a **Port Call** by calling the
 
-            PUT /v2/port-calls/{portCallID}
+            PUT /port-calls/{portCallID}
 
      - Create a **Terminal Call** and link it to the **Port Call** created above by calling
 
-            PUT /v2/terminal-calls/{terminalCallID}
-            
+            PUT /terminal-calls/{terminalCallID}
+    
      - Create a **Port Call Service** and link it to the **Terminal Call** created above by calling
-            
-            PUT /v2/port-call-services/{portCallServiceID}
+    
+            PUT /port-call-services/{portCallServiceID}
 
     It is the responsibility of the Provider of the initial **Port Call Service** to create a:
     - `portCallID` to identify all communication regarding the **Port Call**
@@ -85,7 +85,7 @@ tags:
     description: |
       **Provider** and **Consumer** implemented endPoints
 paths:
-  '/v2/port-calls/{portCallID}':
+  '/port-calls/{portCallID}':
     put:
       parameters:
         - $ref: '#/components/parameters/portCallIDPathParam'
@@ -98,7 +98,7 @@ paths:
         Creates or updates a **Port Call** record. The caller must provide a unique `portCallID` (UUIDv4), which identifies the **Port Call**. The `portCallID` must remain consistent across all subsequent communications and linked **Terminal Calls**. If updating an existing **Port Call**, e.g. including the `portVisitReference`, the provided `portCallID` must match the existing record.
 
         The **Port Call** includes:
-          
+        
           - Location information (required): `UNLocationCode`
           - static **Vessel** information (required): `vessel`
           - an optional business identifier for the port visit: `portVisitReference`
@@ -175,7 +175,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'Vessel object not found - it is a mandatory property in Port Call.'
@@ -206,7 +206,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 409
                     statusCodeText: 'Conflict'
                     statusCodeMessage: 'Trying to update a Port Call that has been OMITTED'
@@ -236,7 +236,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Port Call'
@@ -263,14 +263,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        PUT /v2/port-calls/{portCallID}
-                        
+                        PUT /port-calls/{portCallID}
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to create a Port Call has been requested. Please try again in 1 hour'
@@ -280,7 +280,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Port Call requests reached'
                         errorCodeMessage: 'A maximum of 100 unique Port Calls can be requested per hour'
-  '/v2/port-calls/{portCallID}/omit':
+  '/port-calls/{portCallID}/omit':
     post:
       parameters:
         - $ref: '#/components/parameters/portCallIDPathParam'
@@ -354,7 +354,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7004` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'isFYI has wrong type - boolean expected but integer found'
@@ -385,7 +385,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'portCallID not found'
@@ -415,7 +415,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Port Call'
@@ -442,14 +442,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        POST /v2/port-calls/{portCallID}/omit
-                        
+                        POST /port-calls/{portCallID}/omit
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/port-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to omit a Port Call has been requested. Please try again in 1 hour'
@@ -459,7 +459,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Port Call omits reached'
                         errorCodeMessage: 'A maximum of 100 unique Port Calls can be omitted per hour'
-  '/v2/port-calls':
+  '/port-calls':
     get:
       parameters:
         - $ref: '#/components/parameters/portCallIDQueryParam'
@@ -511,7 +511,7 @@ paths:
                   description: |
                     Get a list of all **Port Calls** visiting a port with `UNLocationCode` matching `NLAMS` (Amsterdam in the Netherlands). The request would look like this:
 
-                        GET /v2/port-calls?UNLocationCode=NLAMS
+                        GET /port-calls?UNLocationCode=NLAMS
 
                     **Note:** This will only return **Port Calls** that have not been completed. See endPoint description for a definition of "Completed Port Call"
                   value:
@@ -551,7 +551,7 @@ paths:
                   description: |
                     Get a list of all **Port Calls** that the vessel with `vesselIMONumber=9929429` visits. The request would look like this:
 
-                        GET /v2/port-calls?vesselIMONumber=9929429
+                        GET /port-calls?vesselIMONumber=9929429
 
                     **Note:** This will only return **Port Calls** that have not been completed. See endPoint description for a definition of "Completed Port Call"
                   value:
@@ -605,7 +605,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/port-calls'
+                    requestUri: '/port-calls'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Port Call request'
@@ -632,14 +632,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        GET /v2/port-calls
-                        
+                        GET /port-calls
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/port-calls'
+                    requestUri: '/port-calls'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to fetch Port Calls has been requested. Please try again in 1 hour'
@@ -649,7 +649,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Port Call requests reached'
                         errorCodeMessage: 'A maximum of 500 Port Calls can be requested per hour'
-  '/v2/terminal-calls/{terminalCallID}':
+  '/terminal-calls/{terminalCallID}':
     put:
       parameters:
         - $ref: '#/components/parameters/terminalCallIDPathParam'
@@ -662,7 +662,7 @@ paths:
         Creates or updates a **Terminal Call** record. The caller must provide a unique `terminalCallID` (UUIDv4), which identifies the **Terminal Call**. The `terminalCallID` must remain consistent across all subsequent communications and linked **Port Call Services**. If updating an existing **Terminal Call**, e.g. including the `terminalCallReference`, the provided `terminalCallID` must match the existing record.
 
         The **Terminal Call** includes:
-          
+        
           - link to the **Port Call** (required): `portCallID`
           - Service information (required): `carrierServiceCode`, `carrierServiceName` (and an optional `universalServiceReference`)
           - Voyage information: `carrierImportVoyageNumber`, `carrierExportVoyageNumber`, `universalImportVoyageReference` and `universalExportVoyageReference`
@@ -741,7 +741,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'carrierServiceCode not found - it is a mandatory property in Terminal Call'
@@ -772,7 +772,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'portCallID not found'
@@ -802,7 +802,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 409
                     statusCodeText: 'Conflict'
                     statusCodeMessage: 'Trying to update a Terminal Call that has been OMITTED'
@@ -832,7 +832,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Terminal Call'
@@ -859,14 +859,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        PUT /v2/terminal-calls/{terminalCallID}
-                        
+                        PUT /terminal-calls/{terminalCallID}
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to create a Terminal Call has been requested. Please try again in 1 hour'
@@ -876,7 +876,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Terminal Call requests reached'
                         errorCodeMessage: 'A maximum of 100 unique Terminal Calls can be requested per hour'
-  '/v2/terminal-calls/{terminalCallID}/omit':
+  '/terminal-calls/{terminalCallID}/omit':
     post:
       parameters:
         - $ref: '#/components/parameters/terminalCallIDPathParam'
@@ -949,7 +949,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7004` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'isFYI has wrong type - boolean expected but integer found'
@@ -980,7 +980,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'terminalCallID not found'
@@ -1010,7 +1010,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Terminal Call'
@@ -1037,14 +1037,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        POST /v2/terminal-calls/{terminalCallID}/omit
-                        
+                        POST /terminal-calls/{terminalCallID}/omit
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/omit'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to omit a Terminal Call has been requested. Please try again in 1 hour'
@@ -1054,7 +1054,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Terminal Call omits reached'
                         errorCodeMessage: 'A maximum of 100 unique Terminal Calls can be omitted per hour'
-  '/v2/terminal-calls':
+  '/terminal-calls':
     get:
       parameters:
         - $ref: '#/components/parameters/portCallIDQueryParam'
@@ -1122,7 +1122,7 @@ paths:
                   description: |
                     Get all the **Terminal Calls** that matches the `portCallID=0342254a-5927-4856-b9c9-aa12e7c00563`. The request would look like this:
 
-                        GET /v2/terminal-calls?portCallID=0342254a-5927-4856-b9c9-aa12e7c00563
+                        GET /terminal-calls?portCallID=0342254a-5927-4856-b9c9-aa12e7c00563
 
                     In this example there are 2 **Terminal Calls** linked to the **Port Call** with `portCallID=0342254a-5927-4856-b9c9-aa12e7c00563`
                     The default value for the `omitted` property is `false` so in the below example it does not matter if it is provided or not. For clarity it is provided here.
@@ -1169,7 +1169,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/terminal-calls'
+                    requestUri: '/terminal-calls'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Terminal Call request'
@@ -1196,14 +1196,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        GET /v2/terminal-calls
-                        
+                        GET /terminal-calls
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/terminal-calls'
+                    requestUri: '/terminal-calls'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to fetch a list of Terminal Calls has been requested. Please try again in 1 hour'
@@ -1213,7 +1213,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Terminal Call requests reached'
                         errorCodeMessage: 'A maximum of 1000 Terminal Calls can be requested per hour'
-  '/v2/port-call-services/{portCallServiceID}':
+  '/port-call-services/{portCallServiceID}':
     put:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
@@ -1226,7 +1226,7 @@ paths:
         Creates or updates a **Port Call Service** record. The caller must provide a unique `portCallServiceID` (UUIDv4), which identifies the **Port Call Service**. The `portCallServiceID` must remain consistent across all subsequent communications and linked **Timestamps**. If updating an existing **Port Call Service**, e.g. updating the `moves`, the provided `portCallServiceID` must match the existing record.
 
         The **Port Call Service** includes:
-          
+        
           - link to the **Terminal Call** (required): `terminalCallID`
           - type of Service (required): `portCallServiceType` and `portCallServiceEventTypeCode` (and optionally `portCallPhaseTypeCode` and `facilityTypeCode`)
           - a location (required): `portCallServiceLocation`
@@ -1268,7 +1268,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'portCallServiceType not found - it is a mandatory property in Port Call Service.'
@@ -1299,7 +1299,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'terminalCallID not found'
@@ -1329,7 +1329,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 409
                     statusCodeText: 'Conflict'
                     statusCodeMessage: 'Trying to update a CANCELLED Port Call Service'
@@ -1359,7 +1359,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Port Call Service'
@@ -1386,14 +1386,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        PUT /v2/port-call-services/{portCallServiceID}
-                        
+                        PUT /port-call-services/{portCallServiceID}
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to create a Port Call Service has been requested. Please try again in 1 hour'
@@ -1403,7 +1403,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Port Call Service requests reached'
                         errorCodeMessage: 'A maximum of 100 unique Port Call Services can be requested per hour'
-  '/v2/port-call-services/{portCallServiceID}/cancel':
+  '/port-call-services/{portCallServiceID}/cancel':
     post:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
@@ -1456,7 +1456,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7004` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'isFYI has wrong type - boolean expected but integer found'
@@ -1487,7 +1487,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'portCallServiceID not found'
@@ -1517,7 +1517,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Port Call Service'
@@ -1543,14 +1543,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        POST /v2/port-call-services/{portCallServiceID}/cancel
-                        
+                        POST /port-call-services/{portCallServiceID}/cancel
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/cancel'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to cancel a Port Call Service has been requested. Please try again in 1 hour'
@@ -1560,7 +1560,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Port Call Service cancellations reached'
                         errorCodeMessage: 'A maximum of 100 unique Port Call Services can be cancelled per hour'
-  '/v2/port-call-services':
+  '/port-call-services':
     get:
       parameters:
         - $ref: '#/components/parameters/terminalCallIDQueryParam'
@@ -1612,7 +1612,7 @@ paths:
                   description: |
                     Get all the **Port Call Services** that matches the `terminalCallID=0342254a-5927-4856-b9c9-aa12e7c00563`. The request would look like this:
 
-                        GET /v2/port-call-services?terminalCallID=0342254a-5927-4856-b9c9-aa12e7c00563
+                        GET /port-call-services?terminalCallID=0342254a-5927-4856-b9c9-aa12e7c00563
 
                     In this example there are 2 **Port Call Services** linked to the **Terminal Call** with `terminalCallID=0342254a-5927-4856-b9c9-aa12e7c00563`
                     The default value for the `cancelled` and `declined` property is `false` so in the below example it does not matter if it is provided or not. For clarity it is provided here.
@@ -1641,7 +1641,7 @@ paths:
                   description: |
                     Get all the `Moves` for **Port Call Services** that matches the `terminalCallID=0342254a-5927-4856-b9c9-aa12e7c00563`. The request would look like this:
 
-                        GET /v2/port-call-services?terminalCallID=0342254a-5927-4856-b9c9-aa12e7c00563&portCallServiceType=MOVES
+                        GET /port-call-services?terminalCallID=0342254a-5927-4856-b9c9-aa12e7c00563&portCallServiceType=MOVES
 
                     In this example there is a single `Moves` object for the **Port Call Service** linked to the **Terminal Call**
                     The default value for the `cancelled` and `declined` property is `false` so in the below example it does not matter if it is provided or not. For clarity it is provided here.
@@ -1679,7 +1679,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/port-call-services'
+                    requestUri: '/port-call-services'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while fetching Port Call Service'
@@ -1705,14 +1705,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        GET /v2/port-call-services
-                        
+                        GET /port-call-services
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/port-call-services'
+                    requestUri: '/port-call-services'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to fetch a list of Port Call Services has been requested. Please try again in 1 hour'
@@ -1722,7 +1722,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Port Call Service requests reached'
                         errorCodeMessage: 'A maximum of 1000 Port Call Services can be requested per hour'
-  '/v2/timestamps/{timestampID}':
+  '/timestamps/{timestampID}':
     put:
       parameters:
         - $ref: '#/components/parameters/timestampIDPathParam'
@@ -1735,7 +1735,7 @@ paths:
         Creates or updates a **Timestamp** record. The caller must provide a unique `timestampID` (UUIDv4), which identifies the **Timestamp**. If updating an existing **Timestamp**, e.g. updating the `delayReasonCode`, the provided `timestampID` must match the existing record.
 
         The **Timestamp** includes:
-          
+        
           - link to the **Port Call Service** (required): `portCallServiceID`
           - link to the **Timestamp** it replies to (in case it is not the initial **Timestamp*): `replyToTimestampID`
           - a ERP-A classification (required): `classifierCode`
@@ -1779,7 +1779,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'classifierCode property not found - it is a mandatory property in Timestamp'
@@ -1810,7 +1810,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'portCallServiceID not found'
@@ -1840,7 +1840,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 409
                     statusCodeText: 'Conflict'
                     statusCodeMessage: 'Trying to link a Timestamp to a CANCELLED Port Call Service'
@@ -1870,7 +1870,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Timestamp'
@@ -1897,14 +1897,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        PUT /v2/timestamps/{timestampID}
-                        
+                        PUT /timestamps/{timestampID}
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/timestamps/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to create a Timestamp has been requested. Please try again in 1 hour'
@@ -1914,7 +1914,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Timestamp requests reached'
                         errorCodeMessage: 'A maximum of 100 unique Timestamps can be requested per hour'
-  '/v2/timestamps':
+  '/timestamps':
     get:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDQueryParam'
@@ -1965,7 +1965,7 @@ paths:
                   description: |
                     Get all the **Timestamps** that matches the `portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973`. The request would look like this:
 
-                        GET /v2/timestamps?portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973
+                        GET /timestamps?portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973
 
                     In this example there are 3 **Timestamps** linked to the **Port Call Service** with `portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973`. An `EST` (Estimated), then a `REQ` (Requested) suggesting an hour later and last a `PLN` (Planned) confirming the `REQ`
                   value:
@@ -2003,7 +2003,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/timestamps'
+                    requestUri: '/timestamps'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Timestamp'
@@ -2030,14 +2030,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        GET /v2/timestamps
-                        
+                        GET /timestamps
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/timestamps'
+                    requestUri: '/timestamps'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to fetch a list of Timestamps has been requested. Please try again in 1 hour'
@@ -2047,7 +2047,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Timestamp requests reached'
                         errorCodeMessage: 'A maximum of 1000 Timestamps can be requested per hour'
-  '/v2/vessel-statuses/{portCallServiceID}':
+  '/vessel-statuses/{portCallServiceID}':
     put:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
@@ -2060,7 +2060,7 @@ paths:
         Updates a **Vessel Status** record for a **Port Call Service**. The caller must provide a `portCallServiceID` (UUIDv4), which identifies the **Port Call Service** to update.
 
         The **Vessel Status** includes:
-          
+        
           - link to the **Port Call Service** (required): `portCallServiceID`
           - dynamic information about a Vessel: `draft`, `airDraft`, `aftDraft`, `forwardDraft`, `vesselPosition` and `milesToDestinationPort` 
           - The ability to send the record with informational purpose only, using `isFYI=true`
@@ -2100,7 +2100,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/vessel-statuses/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/vessel-statuses/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'portCallServiceID object not found - it is a mandatory property in Vessel Status'
@@ -2131,7 +2131,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/vessel-statuses/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/vessel-statuses/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'portCallServiceID not found'
@@ -2161,7 +2161,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7003` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/vessel-status/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/vessel-status/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 409
                     statusCodeText: 'Conflict'
                     statusCodeMessage: 'Trying to update the Vessel Status for a CANCELLED Port Call Service'
@@ -2191,7 +2191,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/vessel-statuses/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/vessel-statuses/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Vessel Status'
@@ -2218,14 +2218,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        PUT /v2/vessel-status/{portCallStatusID}
-                        
+                        PUT /vessel-status/{portCallStatusID}
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'PUT'
-                    requestUri: '/v2/vessel-status/085a3207-5e45-49cf-8e1b-f8442beaf545'
+                    requestUri: '/vessel-status/085a3207-5e45-49cf-8e1b-f8442beaf545'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to update the Vessel Status has been requested. Please try again in 1 hour'
@@ -2235,7 +2235,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Vessel Status updates reached'
                         errorCodeMessage: 'A maximum of 100 unique Vessel Status can be updated per hour'
-  '/v2/vessel-statuses':
+  '/vessel-statuses':
     get:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDRequiredQueryParam'
@@ -2278,7 +2278,7 @@ paths:
                   description: |
                     Get all the **Vessel Statuses** that matches the `portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973`. The request would look like this:
 
-                        GET /v2/vessel-Statuses?portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973
+                        GET /vessel-Statuses?portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973
 
                     In this example there are 3 **Vessel Statuses** linked to the **Port Call Service** with `portCallServiceID=20648fdc-4287-4e0f-81e8-f5ad9b3e5973`.
                   value:
@@ -2326,7 +2326,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/vessel-statuses'
+                    requestUri: '/vessel-statuses'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Vessel Status'
@@ -2353,14 +2353,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        GET /v2/vessel-statuses
-                        
+                        GET /vessel-statuses
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'GET'
-                    requestUri: '/v2/vessel-statuses'
+                    requestUri: '/vessel-statuses'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to fetch a list of Vessel Statuses has been requested. Please try again in 1 hour'
@@ -2370,7 +2370,7 @@ paths:
                       - errorCode: 7003
                         errorCodeText: 'Max Vessel Status requests reached'
                         errorCodeMessage: 'A maximum of 1000 Vessel Statuses can be requested per hour'
-  '/v2/port-call-services/{portCallServiceID}/decline':
+  '/port-call-services/{portCallServiceID}/decline':
     post:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
@@ -2424,7 +2424,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7004` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
                     statusCode: 400
                     statusCodeText: 'Bad Request'
                     statusCodeMessage: 'isFYI has wrong type - boolean expected but integer found'
@@ -2455,7 +2455,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7006` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
                     statusCode: 404
                     statusCodeText: 'Not Found'
                     statusCodeMessage: 'portCallServiceID not found'
@@ -2485,7 +2485,7 @@ paths:
                     **NB**: `errorCode` not yet standardized by DCSA. Value `7005` is just a "random example"
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
+                    requestUri: '/port-call-services/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
                     statusCode: 500
                     statusCodeText: 'Internal Server Error'
                     statusCodeMessage: 'Internal Server Error occurred while processing Port Call Service'
@@ -2511,14 +2511,14 @@ paths:
                   description: |
                     Calling the endPoint
 
-                        POST /v2/port-call-services/{portCallServiceID}/decline
-                        
+                        POST /port-call-services/{portCallServiceID}/decline
+                    
                     too many times within a time period results in an error.
 
                     **NB**: The `errorCode` is not yet standardized by DCSA. The value `7003` is just a "random example".
                   value:
                     httpMethod: 'POST'
-                    requestUri: '/v2/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
+                    requestUri: '/terminal-calls/085a3207-5e45-49cf-8e1b-f8442beaf545/decline'
                     statusCode: 429
                     statusCodeText: 'Too Many Requests'
                     statusCodeMessage: 'Too many requests to decline a Port Call Service has been requested. Please try again in 1 hour'
@@ -2633,16 +2633,16 @@ components:
         pattern: ^\S(?:.*\S)?$
         example: FE1
     universalServiceReferenceQueryParam:
-        in: query
-        name: universalServiceReference
-        description: |
-          The **Universal Service Reference** (`USR`) as defined by DCSA to filter by. Specifying this filter will ensure that the result set contains only objects where the `universalServiceReference` property is present and its value matches one of the values of the corresponding filter query parameter.
-        schema:
-          type: string
-          pattern: ^SR\d{5}[A-Z]$
-          maxLength: 8
-          minLength: 8
-          example: SR12345A
+      in: query
+      name: universalServiceReference
+      description: |
+        The **Universal Service Reference** (`USR`) as defined by DCSA to filter by. Specifying this filter will ensure that the result set contains only objects where the `universalServiceReference` property is present and its value matches one of the values of the corresponding filter query parameter.
+      schema:
+        type: string
+        pattern: ^SR\d{5}[A-Z]$
+        maxLength: 8
+        minLength: 8
+        example: SR12345A
 
     # Terminal Call query parameters
 
@@ -3236,7 +3236,7 @@ components:
     Timestamps:
       type: array
       description: |
-         An array of **Timestamps** matching the filters provided.
+        An array of **Timestamps** matching the filters provided.
       items:
         $ref: '#/components/schemas/Timestamp'
 
@@ -4076,7 +4076,7 @@ components:
           description: |
             The URI that was requested.
           type: string
-          example: /v2/port-call-services/0342254a-5927-4856-b9c9-aa12e7c00563
+          example: /port-call-services/0342254a-5927-4856-b9c9-aa12e7c00563
         statusCode:
           description: |
             The HTTP status code returned.


### PR DESCRIPTION
[SD-1824](https://dcsa.atlassian.net/browse/SD-1824): Removing 'v2/' from all URLs/examples and descriptions.

FYI: @jkosternl and @gj0dcsa 

[SD-1824]: https://dcsa.atlassian.net/browse/SD-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ