### PR TITLE
SD-2046: JIT 2.0: Make API-Version header required

### DIFF
--- a/jit/v2/JIT_v2.0.0.yaml
+++ b/jit/v2/JIT_v2.0.0.yaml
@@ -2540,6 +2540,7 @@ components:
         example: 2.0.0
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
+      required: true
   parameters:
     Api-Version-Major:
       in: header


### PR DESCRIPTION
Make sure the spec follows the API DNI principles:

> A custom header called API-Version MUST be added in the response to specify the full version. The API-Version custom header in the response MUST include complete version information for example: API-Version: 2.0.0-beta-3. An API Consumer MAY use this information to adapt processing of the response in order to make use of features introduced into later versions of the standard.