### PR TITLE
SD-2062: JIT 2.0: Add `sender` and `receiver` headers

### DIFF
--- a/jit/v2/JIT_v2.0.0.yaml
+++ b/jit/v2/JIT_v2.0.0.yaml
@@ -90,6 +90,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-port-call
@@ -286,6 +288,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: omit-port-call
@@ -472,6 +476,8 @@ paths:
         - $ref: '#/components/parameters/MMSINumberQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-port-call
@@ -655,6 +661,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/terminalCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-terminal-call
@@ -872,6 +880,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/terminalCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: omit-terminal-call
@@ -1061,6 +1071,8 @@ paths:
         - $ref: '#/components/parameters/universalExportVoyageReferenceQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-terminal-call
@@ -1209,6 +1221,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-port-call-service
@@ -1387,6 +1401,9 @@ paths:
     post:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
+        - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: cancel-port-call-service
@@ -1549,6 +1566,8 @@ paths:
         - $ref: '#/components/parameters/portCallServiceTypeQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-port-call-services
@@ -1707,6 +1726,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/timestampIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service
       operationId: put-timestamp
@@ -1892,6 +1913,8 @@ paths:
         - $ref: '#/components/parameters/classifierCodeQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-timestamp
@@ -2022,6 +2045,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-vessel-status
@@ -2210,6 +2235,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDRequiredQueryParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-vessel-status
@@ -2345,6 +2372,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
+        - $ref: '#/components/parameters/Sending-Party'
+        - $ref: '#/components/parameters/Receiving-Party'
       tags:
         - Port Call Service - Service Provider
       operationId: decline-port-call-service
@@ -2518,6 +2547,26 @@ components:
         example: '2'
       description: |
         An API-Version header **MAY** be added to the request (optional); if added it **MUST** only contain **MAJOR** version. API-Version header **MUST** be aligned with the URI version.
+    Sending-Party:
+      in: header
+      name: Sending-Party
+      required: false
+      schema:
+        type: string
+        maxLength: 4096
+        example: 'Sender-7101ad01-d608-483c-b746-e060ba335d51'
+      description: |
+        In case the request is being sent **on behalf of** another party - it is possible to add the identifier of the party `Sending` the message here. This header can be used when relaying messages.
+    Receiving-Party:
+      in: header
+      name: Receiving-Party
+      required: false
+      schema:
+        type: string
+        maxLength: 4096
+        example: 'Request-Receiver-fff76466-070b-463e-8dc2-efc55f108e74'
+      description: |
+        In case the request needs to be received **on behalf of** another party - it is possible to add the identifier of the party `Receiving` the message here. This header can be used when relaying messages.
     ##############
     # Query params
     ##############


### PR DESCRIPTION
[SD-2062](https://dcsa.atlassian.net/browse/SD-2062): Adding a `Sending-Party` and `Receiving-Party` to all requests in JIT

Fixed missing `API-Version` header on the **port-call-Service** cancel endPoint

[SD-2062]: https://dcsa.atlassian.net/browse/SD-2062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ