### PR TITLE
SD-2093: JIT 2.0: Change OPTION -> OPTIONS in Error object

### DIFF
--- a/jit/v2/JIT_v2.0.0.yaml
+++ b/jit/v2/JIT_v2.0.0.yaml
@@ -4401,7 +4401,7 @@ components:
             - POST
             - PUT
             - DELETE
-            - OPTION
+            - OPTIONS
             - PATCH
         requestUri:
           description: |


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected HTTP method name from `OPTION` to `OPTIONS` in the error object.

- Ensured consistency with standard HTTP method naming conventions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JIT_v2.0.0.yaml</strong><dd><code>Corrected HTTP method name in error object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jit/v2/JIT_v2.0.0.yaml

<li>Replaced <code>OPTION</code> with <code>OPTIONS</code> in the list of HTTP methods.<br> <li> Updated the <code>enum</code> field for HTTP methods in the error object <br>definition.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/505/files#diff-9515d70681d4860776aad1fa65c622e5b362021ad1f0c0ae1352067f49108299">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>