### PR TITLE
SD-2095: JIT 2.0: Update What's New for 28 March 2025 publication

### DIFF
--- a/jit/v2/README.md
+++ b/jit/v2/README.md
@@ -6,6 +6,22 @@ The DCSA Interface Standard for Just in Time Portcalls is documented on the **[D
 ---
 This is a moving target and will be updated as soon as the version is published
 
+<a name="v200B20250328"></a>[Release v2.0.0 Beta 20250328 (28 of March 2025)](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_JIT/2.0.0-Beta-20250328)
+---
+Snapshot as of 28 of March 2025 for JIT 2.0.0 Beta.
+## Key changes
+- added 2 new headers: `Response-Sending-Party` and `Response-Receiving-Party` to all endPoint responses (this allows relaying JIT messages through 3rd party system)
+- renamed 2 headers: `Sending-Party` and `Receiving-Party` to `Request-Sending-Party` and `Request-Receiving-Party`
+- changed the `httpMethod` enum value `OPTION` --> `OPTIONS` in the Error object
+
+## Minor changes
+- improved some descriptions and modified some whitespace for better readability
+- updated some `statusCode` error examples from `404` -> `400`
+- fixed missing `'` in an example
+- updated example values and description on the `Request-Sending-Party` and `Request-Receiving-Party` headers to make it more clear
+
+Link to [commits included in this Snapshot](https://github.com/dcsaorg/DCSA-OpenAPI/commits/master/jit/v2/JIT_v2.0.0.yaml?since=2025-03-15&until=2025-03-28)
+
 <a name="v200B20250314"></a>[Release v2.0.0 Beta 20250314 (14 of March 2025)](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_JIT/2.0.0-Beta-20250314)
 ---
 Snapshot as of 14 of March 2025 for JIT 2.0.0 Beta.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added release notes for JIT 2.0.0 Beta (28 March 2025).

- Documented key changes including header additions and renaming.

- Highlighted minor updates like improved descriptions and example fixes.

- Provided a link to commits included in the snapshot.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Added release notes and documented updates for JIT 2.0.0 Beta</code></dd></summary>
<hr>

jit/v2/README.md

<li>Added release notes for JIT 2.0.0 Beta (28 March 2025).<br> <li> Documented key changes: header additions, renaming, and enum value <br>update.<br> <li> Included minor updates: description improvements, example fixes, and <br>whitespace adjustments.<br> <li> Linked to commits relevant to the snapshot.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/507/files#diff-875c0193e7545330e8b54903613a8d37683c205f2488f16ea41ad3a7c4e0a673">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>