### PR TITLE
BKG 2.0: Disallow any changes to BKG v2.0.1

### DIFF
--- a/.github/forbidden_changes.txt
+++ b/.github/forbidden_changes.txt
@@ -3,6 +3,7 @@ bkg/v1/bkg_v1.0.0-Beta-1.yaml
 bkg/v1/bkg_v1.0.0-Beta-2.yaml
 bkg/v2/notification/*
 bkg/v2/BKG_v2.0.0.yaml
+bkg/v2/BKG_v2.0.1.yaml
 bkg/v2/BKG_v2.0.0-Beta-1.yaml
 bkg/v2/BKG_v2.0.0-Beta-2.yaml
 cs/v1/CS_v1.0.0.yaml


### PR DESCRIPTION
BKG v2.0.1 has been released and published. No changes can be done to this API