### PR TITLE
BKG 2.0: SD-2198: Change description of expectedDepartureFromPlaceOfReceiptDate

### DIFF
--- a/bkg/v2/BKG_v2.0.2.yaml
+++ b/bkg/v2/BKG_v2.0.2.yaml
@@ -3091,8 +3091,8 @@ components:
           type: string
           format: date
           description: |
-            The date when the shipment is expected to be loaded on board a vessel at `Place of Receipt` as provided by the shipper or its agent.
-            
+            The date when the shipment is expected to be handed over to the carrier at `Place of Receipt` as provided by the shipper or its agent.
+
             **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POD) is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
@@ -3477,7 +3477,7 @@ components:
           type: string
           format: date
           description: |
-            The date when the shipment is expected to be loaded on board a vessel at `Place of Receipt` as provided by the shipper or its agent.
+            The date when the shipment is expected to be handed over to the carrier at `Place of Receipt` as provided by the shipper or its agent.
             
             **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POD) is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
@@ -3930,7 +3930,7 @@ components:
           type: string
           format: date
           description: |
-            The date when the shipment is expected to be loaded on board a vessel at `Place of Receipt` as provided by the shipper or its agent.
+            The date when the shipment is expected to be handed over to the carrier at `Place of Receipt` as provided by the shipper or its agent.
             
             **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POD) is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'


### PR DESCRIPTION
### **User description**
Improve descriptions based on feedback


___

### **PR Type**
Documentation


___

### **Description**
- Updated the description for `expectedDepartureFromPlaceOfReceiptDate`
  - Clarified that the date refers to handover to the carrier
  - Applied changes consistently across multiple schema sections


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BKG_v2.0.2.yaml</strong><dd><code>Clarify and update expectedDepartureFromPlaceOfReceiptDate description</code></dd></summary>
<hr>

bkg/v2/BKG_v2.0.2.yaml

<li>Updated description for <code>expectedDepartureFromPlaceOfReceiptDate</code> in <br>three schema locations<br> <li> Changed focus from "loaded on board a vessel" to "handed over to the <br>carrier"<br> <li> Ensured consistency in documentation wording across the schema


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/519/files#diff-d5003af897d4cb1d1ad63fb33fb013f79c2bff5ee328389269b46f70a4aa1a8e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>