### PR TITLE
BKG 2.0: SD_2241: Fix typo in expectedDepartureFromPlaceOfReceiptDate

### DIFF
--- a/bkg/v2/BKG_v2.0.2.yaml
+++ b/bkg/v2/BKG_v2.0.2.yaml
@@ -3093,7 +3093,7 @@ components:
           description: |
             The date when the shipment is expected to be handed over to the carrier at `Place of Receipt` as provided by the shipper or its agent.
 
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POD) is not provided. If `routingReference` is provided - this property MUST not be provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POL) is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3479,7 +3479,7 @@ components:
           description: |
             The date when the shipment is expected to be handed over to the carrier at `Place of Receipt` as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POD) is not provided. If `routingReference` is provided - this property MUST not be provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POL) is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string
@@ -3932,7 +3932,7 @@ components:
           description: |
             The date when the shipment is expected to be handed over to the carrier at `Place of Receipt` as provided by the shipper or its agent.
             
-            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POD) is not provided. If `routingReference` is provided - this property MUST not be provided.
+            **Condition:** Mandatory if vessel/voyage/service details or `expectedArrivalAtPlaceOfDeliveryDate` or `expectedDepartureDate` (at POL) is not provided. If `routingReference` is provided - this property MUST not be provided.
           example: '2021-05-17'
         expectedArrivalAtPlaceOfDeliveryStartDate:
           type: string


### PR DESCRIPTION
### **User description**
`POD` must be changed to `POL` for `expectedDepartureFromPlaceOfReceiptDate`


___

### **PR Type**
Bug fix


___

### **Description**
- Fix typo in API documentation changing POD to POL

- Correct shipping terminology in condition descriptions

- Update three instances of the same error


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BKG_v2.0.2.yaml</strong><dd><code>Fix POD to POL typo in API documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bkg/v2/BKG_v2.0.2.yaml

<li>Fixed typo in three locations changing "POD" to "POL" in condition <br>descriptions<br> <li> Corrected shipping terminology for Place of Loading reference<br> <li> Updated <code>expectedDepartureFromPlaceOfReceiptDate</code> field documentation


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/521/files#diff-d5003af897d4cb1d1ad63fb33fb013f79c2bff5ee328389269b46f70a4aa1a8e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>