### PR TITLE
BKG 2.0: SD-2267: Fix GET, PUT and PATCH description

### DIFF
--- a/bkg/v2/BKG_v2.0.2.yaml
+++ b/bkg/v2/BKG_v2.0.2.yaml
@@ -552,7 +552,7 @@ paths:
         - $ref: '#/components/parameters/bookingReferencePathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
       description: |
-        Updates the `Booking Request` with the `bookingReference`. The path can contain one of `carrierBookingRequestReference` or `carrierBookingReference`. Once a Booking has been `CONFIRMED` the `carrierBookingReference` **MUST** always be used. This endPoint corresponds with one of
+        Updates the `Booking Request` with the `bookingReference`. The path can contain one of `carrierBookingRequestReference` or `carrierBookingReference`. This endPoint corresponds with one of
         - **UseCase 3 - Submit updated Booking request**
         - **UseCase 7 - Request amendments to confirmed Booking**
 
@@ -1119,7 +1119,7 @@ paths:
         Gets the Booking
       operationId: get-bookings
       description: |
-        Retrieves the `Booking Request` with the `bookingReference`. The path can contain a `carrierBookingRequestReference` or a `carrierBookingReference`. Once the Booking is confirmed - it is **only** possible to use the `carrierBookingReference`. It is recommended to use this endPoint to `GET` data before an update is made to make sure latest version is being updated.
+        Retrieves the `Booking Request` with the `bookingReference`. The path can contain a `carrierBookingRequestReference` or a `carrierBookingReference`. It is recommended to use this endPoint to `GET` data before an update is made to make sure latest version is being updated.
 
         The default payload when calling this endPoint is the "original" `Booking`. It is also possible to get the latest amendment to a `Booking` called the `Amended Booking`. In order to get the `Amended Booking`, it is necessary to use the query parameter `amendedContent` and set it to `true`.
 
@@ -1509,7 +1509,7 @@ paths:
         Cancels the Booking or cancels an Amendment
       operationId: cancel-booking
       description: |
-        A shipper initiated cancellation of the `Booking` or `Booking Amendment` with the `bookingReference`. The path can contain a `carrierBookingRequestReference` or a `carrierBookingReference`. Once the `Booking` is confirmed - it is **only** possible to use the `carrierBookingReference`.
+        A shipper initiated cancellation of the `Booking` or `Booking Amendment` with the `bookingReference`. The path can contain a `carrierBookingRequestReference` or a `carrierBookingReference`.
 
         This endPoint corresponds with **UseCase 11 - Cancel Booking Request by shipper**, **UseCase 9 - Cancel amendment to confirmed Booking** or **UseCase 13 - Cancel confirmed Booking by shipper**.
 

--- a/bkg/v2/README.md
+++ b/bkg/v2/README.md
@@ -9,10 +9,10 @@ Publications related to the Booking API:
 
 <a name="v202"></a>[Release v2.0.2 (TBD)](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_BKG/2.0.2)
 ---
-This is a patch release for the DCSA Booking API. A lot of minor changes have been added to this patch, here is a list of changes
+This is a patch release for the DCSA Booking API. A bug in the `GET`, `PUT` and `PATCH` description has been fixed (chaning the semantics of the endPoints) and a lot of minor changes have been added to this patch, here is a list of changes
 
 - allow `countryCode` `ZZ` in case it is not known
-- added `expectedDepartureFromPlaceOfReceiptDate` next to `expectedDepartureDate` for the Shipper to also be able to specify the departure date from PoR
+- added `expectedDepartureFromPlaceOfReceiptDate` next to `expectedDepartureDate` for the Shipper to also be able to specify the departure date from `PRE` (Place of Receipt)
 - `transportDocumentReferences` (a list of TDR) to replace `transportDocumentReference` (a single TDR) as a Booking can potentially result in multiple Transport Documents
 - `transportDocumentReference` marked as Deprecated
 - `requestedNumberOfTransportDocuments` added in case the Shipper does not know the TDR(s) but knows how many are needed
@@ -25,8 +25,9 @@ This is a patch release for the DCSA Booking API. A lot of minor changes have be
   - `RAIL_TRUCK`(Rail and truck)
   - `BARGE_TRUCK`(Barge and truck)
   - `BARGE_RAIL`(Barge and rail)
+- fixed a bug in the description of the `PUT`, `GET` and `PATCH`. It is now possible to use CBRR (`carrierBookingRequestReference`) after a Booking has been Confirmed (the description wrongly prevented this). This changes the semantics of the endPoints - but the change is needed as the standard cannot be used as it is in case a Shipper does not implement the ability to receive PUSH notifications.
 
-Link to [commits included in this patch](https://github.com/dcsaorg/DCSA-OpenAPI/commits/master/bkg/v2/BKG_v2.0.2.yaml?since=2025-04-25&until=2025-06-12)
+Link to [commits included in this patch](https://github.com/dcsaorg/DCSA-OpenAPI/commits/master/bkg/v2/BKG_v2.0.2.yaml?since=2025-04-25&until=2025-06-28)
 
 <a name="v201"></a>[Release v2.0.1 (25 April 2025)](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_BKG/2.0.1)
 ---


### PR DESCRIPTION
### **User description**
Fixing a breaking backward compatible bug in the GET, PUT and PATCH endPoint. The semantics of the endPoint has been changed to allow the use of the CBRR (`carrierBookingRequestRefreence`) throughout the lifecyckle of the Booking - also **after** it has been Confirmed.
This change is needed as the Standard would be useless in case a Shipper does not support PUSH messages (as there is no way  for a Shipper to receive the CBR (`carrierBookingReference`)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed API endpoint descriptions for GET, PUT, PATCH operations

- Removed restriction requiring `carrierBookingReference` after booking confirmation

- Updated README to document the semantic changes

- Enabled use of `carrierBookingRequestReference` throughout booking lifecycle


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BKG_v2.0.2.yaml</strong><dd><code>Remove booking reference restrictions from endpoint descriptions</code></dd></summary>
<hr>

bkg/v2/BKG_v2.0.2.yaml

<li>Removed restriction in PUT endpoint description requiring <br><code>carrierBookingReference</code> after confirmation<br> <li> Updated GET endpoint description to allow <br><code>carrierBookingRequestReference</code> usage throughout lifecycle<br> <li> Modified PATCH endpoint description to remove confirmation-based <br>reference restrictions


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/523/files#diff-d5003af897d4cb1d1ad63fb33fb013f79c2bff5ee328389269b46f70a4aa1a8e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document endpoint description bug fix in release notes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bkg/v2/README.md

<li>Added explanation of the bug fix in endpoint descriptions<br> <li> Updated release notes to document semantic changes<br> <li> Clarified the need for CBRR usage when shippers don't support PUSH <br>notifications<br> <li> Updated commit link date range


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/523/files#diff-2ca7f39cb8ae15c76141514b60e5767978a12376a63840f6080db64ba0b1b43c">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>