### PR TITLE
EBL 3.0: SD-2232: Add 'ZZ' option to countryCode

### DIFF
--- a/bkg/v2/BKG_v2.0.3.yaml
+++ b/bkg/v2/BKG_v2.0.3.yaml
@@ -43,7 +43,7 @@ info:
     This API follows the guidelines defined in version 2.0 of the API Design & Implementation Principles which can be found on the [DCSA Developer Portal](https://developer.dcsa.org/api_design)
 
     ### Changelog and GitHub
-    For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/bkg/v2#v202). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
+    For a changelog please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/bkg/v2#v203). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
 
     API specification issued by [DCSA.org](https://dcsa.org/).
   license:
@@ -2246,7 +2246,7 @@ components:
     API-Version:
       schema:
         type: string
-        example: 2.0.2
+        example: 2.0.3
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
   parameters:

--- a/ebl/v3/EBL_v3.0.2.yaml
+++ b/ebl/v3/EBL_v3.0.2.yaml
@@ -44,7 +44,7 @@ info:
     This API follows the guidelines defined in version 2.0 of the API Design & Implementation Principles which can be found on the [DCSA Developer Portal](https://developer.dcsa.org/api_design)
 
     ### Changelog and GitHub
-    For a changelog, please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/ebl/v3#v301). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
+    For a changelog, please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/ebl/v3#v302). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
 
     API specification issued by [DCSA.org](https://dcsa.org/).
   license:
@@ -2605,7 +2605,7 @@ components:
     API-Version:
       schema:
         type: string
-        example: 3.0.1
+        example: 3.0.2
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
   parameters:

--- a/ebl/v3/EBL_v3.0.2.yaml
+++ b/ebl/v3/EBL_v3.0.2.yaml
@@ -4236,6 +4236,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
       required:
         - street
@@ -4271,6 +4273,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
       required:
         - city
@@ -4470,6 +4474,8 @@ components:
           type: string
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           pattern: ^[A-Z]{2}$
           minLength: 2
           maxLength: 2
@@ -5703,6 +5709,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: IN
         value:
           type: string
@@ -6031,6 +6039,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: BR
         values:
           type: array
@@ -6092,6 +6102,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
         values:
           type: array
@@ -7436,6 +7448,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
         advanceManifestFilingsHouseBLPerformedBy:
           type: string
@@ -7597,6 +7611,8 @@ components:
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
             
             **Condition:** Mandatory to provide in case `UN Location Code` is not provided
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
         UNLocationCode:
           type: string
@@ -7643,6 +7659,8 @@ components:
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
             
             **Condition:** Mandatory to provide in case `UN Location Code` is not provided
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
         UNLocationCode:
           type: string
@@ -8556,6 +8574,8 @@ components:
               maxLength: 2
               description: |
                 The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+                **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
               example: NL
           required:
             - countryCode

--- a/ebl/v3/issuance/EBL_ISS_v3.0.2.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.2.yaml
@@ -17,7 +17,7 @@ info:
 
     for the eBL Solution Provider to call.
 
-    When the document is to be surrendered, it should happen via a version of the [DCSA eBL Surrender](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_EBL_SUR/3.0.1) API.
+    When the document is to be surrendered, it should happen via a version of the [DCSA eBL Surrender](https://app.swaggerhub.com/apis-docs/dcsaorg/DCSA_EBL_SUR/3.0.2) API.
 
     ### API Design & Implementation Principles
     This API follows the guidelines defined in version 2.0 of the API Design & Implementation Principles which can be found on the [DCSA Developer Portal](https://developer.dcsa.org/api_design)
@@ -26,7 +26,7 @@ info:
     Please look at the following implementation guide for how to create [Digital Signatures](https://developer.dcsa.org/implementing-digital-signatures-for-transport-documents). 
     
     ### Changelog and GitHub
-    For a changelog, please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/ebl/v3/issuance#v301). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
+    For a changelog, please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/ebl/v3/issuance#v302). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
 
     API specification issued by [DCSA.org](https://dcsa.org/).
   license:
@@ -160,7 +160,7 @@ components:
     API-Version:
       schema:
         type: string
-        example: 3.0.1
+        example: 3.0.2
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
   parameters:

--- a/ebl/v3/issuance/EBL_ISS_v3.0.2.yaml
+++ b/ebl/v3/issuance/EBL_ISS_v3.0.2.yaml
@@ -523,6 +523,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: IN
         value:
           type: string
@@ -1186,6 +1188,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: BR
         values:
           type: array
@@ -1247,6 +1251,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
         values:
           type: array
@@ -2609,6 +2615,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
       required:
         - street
@@ -2644,6 +2652,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
       required:
         - city
@@ -2792,6 +2802,8 @@ components:
           type: string
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           pattern: ^[A-Z]{2}$
           minLength: 2
           maxLength: 2
@@ -3316,6 +3328,8 @@ components:
               maxLength: 2
               description: |
                 The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+                **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
               example: NL
           required:
             - countryCode

--- a/ebl/v3/surrender/EBL_SUR_v3.0.2.yaml
+++ b/ebl/v3/surrender/EBL_SUR_v3.0.2.yaml
@@ -32,7 +32,7 @@ info:
     This API follows the guidelines defined in version 2.0 of the API Design & Implementation Principles which can be found on the [DCSA Developer Portal](https://developer.dcsa.org/api_design)
 
     ### Changelog and GitHub
-    For a changelog, please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/ebl/v3/surrender#v301). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
+    For a changelog, please click [here](https://github.com/dcsaorg/DCSA-OpenAPI/tree/master/ebl/v3/surrender#v302). If you have any questions, feel free to [Contact Us](https://dcsa.org/get-involved/contact-us).
 
     API specification issued by [DCSA.org](https://dcsa.org/).
   license:
@@ -131,7 +131,7 @@ components:
     API-Version:
       schema:
         type: string
-        example: 3.0.1
+        example: 3.0.2
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
   parameters:

--- a/ebl/v3/surrender/EBL_SUR_v3.0.2.yaml
+++ b/ebl/v3/surrender/EBL_SUR_v3.0.2.yaml
@@ -393,6 +393,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: IN
         value:
           type: string

--- a/pint/v3/EBL_PINT_v3.0.0.yaml
+++ b/pint/v3/EBL_PINT_v3.0.0.yaml
@@ -1110,6 +1110,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: IN
         value:
           type: string
@@ -1771,6 +1773,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: BR
         values:
           type: array
@@ -1832,6 +1836,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
         values:
           type: array
@@ -3193,6 +3199,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
       required:
         - street
@@ -3228,6 +3236,8 @@ components:
           maxLength: 2
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           example: NL
       required:
         - city
@@ -3376,6 +3386,8 @@ components:
           type: string
           description: |
             The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+            **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
           pattern: ^[A-Z]{2}$
           minLength: 2
           maxLength: 2
@@ -3823,6 +3835,8 @@ components:
               maxLength: 2
               description: |
                 The 2 characters for the country code using [ISO 3166-1 alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en)
+
+                **Note:** In case the `countryCode` is unknown it is possible to use the code `ZZ`.
               example: NL
           required:
             - countryCode


### PR DESCRIPTION
[SD-2232](https://dcsa.atlassian.net/browse/SD-2232): Make sure to include `ZZ` as `countryCode` in eBL, Issuance, Surrender (if needed) and PINT

[SD-2232]: https://dcsa.atlassian.net/browse/SD-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ