### PR TITLE
BKG 2.0: SD-2384: Remove mandatory cutOffTimes requirement

### DIFF
--- a/bkg/v2/BKG_v2.0.3.yaml
+++ b/bkg/v2/BKG_v2.0.3.yaml
@@ -4102,8 +4102,6 @@ components:
           type: array
           description: |
             A list of cut-off times provided by the carrier in the booking confirmation. A cut-off time indicates the latest deadline within which a task must be completed. The confirmed schedule cannot be guaranteed if a cut-off time is missed. Customs brokers may set additional cut-off times to receive the export customs documentation, which is not included in the shipment cut-off times of a carrier booking.
-
-            **Condition:** Mandatory and non-empty for a `CONFIRMED` Booking
           items:
             $ref: '#/components/schemas/ShipmentCutOffTime'
         advanceManifestFilings:


### PR DESCRIPTION
[SD-2384](https://dcsa.atlassian.net/browse/SD-2384): Remove mandatory `shipmentCutOffTime` requirement

[SD-2384]: https://dcsa.atlassian.net/browse/SD-2384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ