### PR TITLE
Allow OVS 3.0 GitHub to align with SwaggerHub

### DIFF
--- a/.github/forbidden_changes.txt
+++ b/.github/forbidden_changes.txt
@@ -43,7 +43,6 @@ ovs/v2/ovs.yaml
 ovs/v2/ovs_v2.0.0.yaml
 ovs/v2/ovs_v2.0.1.yaml
 ovs/v2/ovs_v2.0.2.yaml
-ovs/v3/OVS_v3.0.0.yaml
 ovs/v3/ovs_v3.0.0-Beta-1.yaml
 ovs/v3/reference-data/*
 ovs_event_hub/*


### PR DESCRIPTION
Removing the `readOnly` state of OVS 3.0 so the file can be aligned with how it looks on SwaggerHub