### PR TITLE
OVS 3.0: SD-2220: Relax on mandatory carrierImportVoyageNumber

### DIFF
--- a/ovs/v3/OVS_v3.0.1.yaml
+++ b/ovs/v3/OVS_v3.0.1.yaml
@@ -332,7 +332,7 @@ components:
           description: |
             The identifier of an import voyage. The carrier-specific identifier of the import Voyage.
 
-            **Note:** In case the `carrierImportVoyageNumber` is not known, `9999R` should be interpreted as "no voyage number".
+            **Note:** In case the `carrierImportVoyageNumber` is not known, `9999R` should be interpreted as "no voyage number". The value `9999R` is reserved as a placeholder and **MUST NOT** be used for real voyage numbers.
           example: 2103N
         carrierExportVoyageNumber:
           type: string


### PR DESCRIPTION
[SD-2220](https://dcsa.atlassian.net/browse/SD-2220): Relax on `carrierImportVoyageReference`
As it is a mandatory property - a convention to use `9999R` is requried in case it is missing

[SD-2220]: https://dcsa.atlassian.net/browse/SD-2220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ