### PR TITLE
BKG 2.0: SD-2471: Require CutOffTimes for Confirmed Bookings

### DIFF
--- a/bkg/v2/BKG_v2.0.3.yaml
+++ b/bkg/v2/BKG_v2.0.3.yaml
@@ -4115,6 +4115,8 @@ components:
           type: array
           description: |
             A list of cut-off times provided by the carrier in the booking confirmation. A cut-off time indicates the latest deadline within which a task must be completed. The confirmed schedule cannot be guaranteed if a cut-off time is missed. Customs brokers may set additional cut-off times to receive the export customs documentation, which is not included in the shipment cut-off times of a carrier booking.
+
+            **Condition:** Mandatory and non-empty for a `CONFIRMED` Booking
           items:
             $ref: '#/components/schemas/ShipmentCutOffTime'
         advanceManifestFilings:


### PR DESCRIPTION
### **User description**
[SD-2471](https://dcsa.atlassian.net/browse/SD-2471): Reintroducing a requirement to have `cutOffTimes` as part of a confirmed Booking
(Essentially reverting #530 )

___

### **PR Type**
Enhancement


___

### **Description**
- Add mandatory requirement for `cutOffTimes` in confirmed bookings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Booking Schema"] --> B["shipmentCutOffTimes Field"]
  B --> C["Add Mandatory Condition"]
  C --> D["CONFIRMED Booking Requirement"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BKG_v2.0.3.yaml</strong><dd><code>Make shipmentCutOffTimes mandatory for confirmed bookings</code></dd></summary>
<hr>

bkg/v2/BKG_v2.0.3.yaml

<ul><li>Added mandatory condition for <code>shipmentCutOffTimes</code> field<br> <li> Requires non-empty cut-off times for confirmed bookings</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/DCSA-OpenAPI/pull/554/files#diff-5761e332ef00fc9c0e9a70532b5fffa1bd328436f759c9e2ac199331b3826dd6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



[SD-2471]: https://dcsa.atlassian.net/browse/SD-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ