### PR TITLE
OVS 3.0: SD-1783: Upgrade license link to https

### DIFF
--- a/ovs/v3/OVS_v3.0.1.yaml
+++ b/ovs/v3/OVS_v3.0.1.yaml
@@ -24,7 +24,7 @@ info:
     email: info@dcsa.org
   license:
     name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 3.0.1
 tags:
   - name: Operational Vessel Schedules


### PR DESCRIPTION
[SD-1783](https://dcsa.atlassian.net/browse/SD-1783): Upgrade license link to `https`